### PR TITLE
Update the README to give a basic description of the Council and the purpose of the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# leadership-council
-Home of the Rust Leadership Council
+# The Rust Project Leadership Council
+
+This repo is the home for documentation related to the Leadership Council for the Rust Programming Language Project (a.k.a. the Council).
+
+The Council was established by [RFC #3392][rfc]. The RFC describes the Council at a high-level as the following:
+
+> This RFC establishes a Leadership Council as the successor of the core team and the new governance structure through which Rust Project members collectively confer the authority to ensure successful operation of the Project. The Leadership Council delegates much of this authority to teams (which includes subteams, working groups, etc.3) who autonomously make decisions concerning their purviews. However, the Council retains some decision-making authority, outlined and delimited by this RFC.
+>
+> The Council will be composed of representatives delegated to the Council from each top-level team.
+>
+> The Council is charged with the success of the Rust Project as a whole. The Council will identify work that needs to be done but does not yet have a clear owner, create new teams to accomplish this work, hold existing teams accountable for the work in their purview, and coordinate and adjust the organizational structure of Project teams.
+
+For more information on *why* the Council exists, please refer to [the supplementary material to RFC #3392][motivation] that addresses this topic.
+
+[rfc]: https://github.com/rust-lang/rfc-leadership-council/blob/63a867ee7a14599e864b4ccba3964a9f086ae400/text/3392-leadership-council.md
+[motivation]: https://github.com/rust-lang/rfc-leadership-council/blob/63a867ee7a14599e864b4ccba3964a9f086ae400/text/3392-leadership-council/motivation.md

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # The Rust Project Leadership Council
 
-This repo is the home for documentation related to the Leadership Council for the Rust Programming Language Project (a.k.a. the Council).
+This repo is the home for documentation related to the [Leadership Council][governance page] for the Rust Programming Language Project (a.k.a. the Council).
 
 The Council was established by [RFC #3392][rfc]. The RFC describes the Council at a high-level as the following:
 
-> This RFC establishes a Leadership Council as the successor of the core team and the new governance structure through which Rust Project members collectively confer the authority to ensure successful operation of the Project. The Leadership Council delegates much of this authority to teams (which includes subteams, working groups, etc.3) who autonomously make decisions concerning their purviews. However, the Council retains some decision-making authority, outlined and delimited by this RFC.
+> This RFC establishes a Leadership Council as the successor of the core team and the new governance structure through which Rust Project members collectively confer the authority to ensure successful operation of the Project. The Leadership Council delegates much of this authority to teams (which includes subteams, working groups, etc.) who autonomously make decisions concerning their purviews. However, the Council retains some decision-making authority, outlined and delimited by this RFC.
 >
-> The Council will be composed of representatives delegated to the Council from each top-level team.
+> The Council [is] composed of representatives delegated to the Council from each top-level team.
 >
 > The Council is charged with the success of the Rust Project as a whole. The Council will identify work that needs to be done but does not yet have a clear owner, create new teams to accomplish this work, hold existing teams accountable for the work in their purview, and coordinate and adjust the organizational structure of Project teams.
 
 For more information on *why* the Council exists, please refer to [the supplementary material to RFC #3392][motivation] that addresses this topic.
 
+If you'd like to participate in conversations about governance or otherwise interact with the Council in some form, you can find the Council on the [Rust Project's Zulip][zulip].
+
+[governance page]: https://www.rust-lang.org/governance/teams/leadership-council
 [rfc]: https://github.com/rust-lang/rfc-leadership-council/blob/63a867ee7a14599e864b4ccba3964a9f086ae400/text/3392-leadership-council.md
 [motivation]: https://github.com/rust-lang/rfc-leadership-council/blob/63a867ee7a14599e864b4ccba3964a9f086ae400/text/3392-leadership-council/motivation.md
+[zulip]: https://rust-lang.zulipchat.com/#narrow/stream/392734-council


### PR DESCRIPTION
While I have quite a few ideas of what would be useful to have on the README, I'd like to start with the basics.

To get consensus on this PR, I'd like to borrow the process we used in the governance RFC working group which is just checkboxes in the PR description. We'll probably want to improve this process over time including potentially using something like RFC bot. 

Checkboxes: 
- [x] @carols10cents 
- [x] @eholk 
- [x] @ehuss 
- [x] @jackh726 
- [x] @khionu 
- [x] @Mark-Simulacrum 
- [x] @m-ou-se 
- [x] @rylev 
- [x] @theJPster
