### PR TITLE
Add link to Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# The Rust Code of Conduct
+
+The Code of Conduct for this repository [can be found online](https://www.rust-lang.org/conduct.html).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # The Rust Code of Conduct
 
-The Code of Conduct for this repository [can be found online](https://www.rust-lang.org/conduct.html).
+This repository follows the Rust Project Code of Conduct, which [can be found on the Rust Language web site](https://www.rust-lang.org/conduct.html).


### PR DESCRIPTION
This adds a link to the Rust Code of Conduct to the repo, so that it is also tracked by GitHub. Although all of the rust-lang org is part of this code of conduct, I think it is good to be explicit in each repo just for clarity. I'm adding just a link to the actual CoC just to avoid needing to deal with synchronizing it should it ever change.
