### PR TITLE
Add minutes from first 2 meetings

### DIFF
--- a/minutes/sync-meeting/2023-06-15.md
+++ b/minutes/sync-meeting/2023-06-15.md
@@ -1,0 +1,108 @@
+# 2023-06-15 
+
+## Agenda
+
+- (turn on recording)
+- Introductions
+- Figure out regular meeting cadence
+- Determine and consent to initial priorities
+    - Communication channel(s)
+      - Zulip stream
+      - public + private?
+    - Mailing list?
+    - Public issue tracker
+- Discuss how we want to make progress between meetings
+- Ryan: note on "formality" of this group
+    - We have run into issues where we were unsure if decisions have been made and who actually consented to what. Being formal can help here (even if it sometimes feels unnecessary)
+- Merge [governance RFC](https://github.com/rust-lang/rfcs/pull/3392)
+- [Merge PR](https://github.com/rust-lang/team/pull/1011) for adding council to rust-lang/team
+- Discuss process for retiring leadership chat and core team
+- Plan process for announcement blog post
+- Enumerate time-sensitive items (this is just to ensure awareness - no action in the meeting needs to take place)
+    - Project Directors the Foundation ((s-)elections set for July?)
+    - Formally establish trademark working group
+- What, if anything, to do with the recording of the meeting
+
+## Minutes
+
+- Unable to record due to technical difficulties, filing an action item to figure that out for the next meeting.
+    - Designated note taker - Mark, Ryan facilitating
+- Initial round of intros/checkins from each representative
+- Figuring out meeting cadence
+    - Ryan: Initial proposal of 1/week
+    - Jonathan seconds
+    - Jonathan: Maybe syncing with release cadence is worthwhile?
+    - Mara: Let's time-limit the decision so we can reconsider rather than going in perpetuity.
+    - Khio: Can we check in once a month?
+    - Carol: Do we need video, or are text-based meetings sufficient?
+    - Ryan: Decision - next 4 weeks, stick for video calls, asynchronously decide on time.
+    - Follow ups:
+        - Jack: What is our absent policy?
+- Ryan: Let's come back to absent policy briefly. RFC provides for alternates.
+    - Ryan: Proposal: 2 representatives allowed to miss (quorum N-2), otherwise canceled.
+    - Ryan: Let's put an action item to double check with RFC.
+    - Eric Huss: Decision making is N-2 but not otherwise specified.
+    - No objections, agreed.
+- Ryan: Determine & consent to initial priorities (first 1-2 weeks).
+    - Ryan: Anything before the next meeting we need to decide other than items on the agenda?
+    - Mara: First priority before anything else is a Zulip stream, already losing track of things.
+        - Jack: We may want at least two streams - one of them being council write-only (but public read).
+        - Eric Holk: A private channel also makes sense, though to be used rarely.
+        - Mara: Write-only does not seem supported in Zulip.
+        - Khio: We have three ideas for streams - public, public-read, private -- do we need three? public-read works poorly in my experience. Early steps - do we need a private stream initially? Most of the initial agenda is public OK. Can we start with just public channel?
+        - Mara: I agree that public-read is solving a problem we don't yet have.
+        - Ryan: Proposal is to create a private channel and a public channel, with the understanding that private should only be used if unavoidable.
+        - Khio: Can we rename the RFC public one?
+        - Mara, Jack: I think a new stream is best. Gives this group ownership.
+        - Ryan: Sticking with proposal of new channels (public + private). Mara owns the action item.
+        - Mara: For private channel, do we establish shared history or protected history? Any objection to sharing with future members? (Can be changed later).
+        - Mara: Let's start with the shared history.
+            - No objections to shared history for private channel.
+    - Next priorities over next 1-1.5 weeks.
+        - Ryan: Proposal: public issue tracker - discuss in public.
+- How are we making decisions?
+    - Jonathan: Let's avoid decisions in Zulip but rather bring to next meeting.
+    - Jack: Let's assign 1-2 people owning coming back with the summary.
+    - Mara: Decisions on Zulip may be better -- e.g., polls (who voted for what) seem better. Every decision being a topic on Zulip may be a better default.
+    - Ryan: +1 to Mara's point. Might also suggest long/mid-term we write out the rationale/caveats, similar to judicial opinions.
+    - Eric Holk: I think we will want asynchronous and synchronous decision making. Written down gives you a clear record of assent.
+    - Eric Huss: Reluctant to use Zulip for decision record (e.g., GitHub seems better in terms of public record).
+- Ryan: Circling back, can we agree on discussing async and pulling that together into the next meeting's agenda?
+    - Mara: Can we make sure that decisions and such don't happen before the next meeting - don't want things to happen when not watching every thread.
+- Ryan: Formality. Can we start with being relatively too formal to ensure we're getting the right level of consent.
+    - Mara: Let's not regress on this accidentally, only intentionally. Need to make sure we don't become sloppy on this.
+    - Jonathan: Practicing formality makes it routine.
+    - Ryan: One starter is 100% consent for all decisions. We need some time to discover what the process is.
+    - Jack: With N-2 absence policy, are we okay with moving ahead? These seem in tension with each other.
+    - Ryan: RFC requires N-2 for decisions, but rather increase to 100%. I think we should make decisions with 9/9 consent to it.
+    - Mara: +1, and should also tend toward not making decisions in meeting, which gives you asynchronous voting. Let's actively decide on changes in the future.
+    - Jack: If people are absent, then we can't make decisions, but I do like async decisions.
+    - Khio: Minimum of 10 days of feedback is specified in the RFC on decisions. (Seems like all decisions).
+    - Eric Holk: Concerned with us deviating from RFC, though in favor of going above myself.
+    - Time check: Noting that there's ~6 minutes left.
+    - Mara: What counts as decision? RFC requires +10 day.
+- Eric Huss: Three things expected today - merge RFC, merge team update, post blog post.
+    - Ryan: Any objections to team repo and RFC merges?
+        - Jack: Let's defer Zulip group to later.
+    - Ryan will own team repo merge.
+    - Mark will own RFC repo merge.
+    - Ryan: Blog post posting - let's move this to an async discussion?
+        - Jack: What is the mechanism for approving that?
+        - Mara: /poll on Zulip is preferred. Do we invalidate votes on small edits?
+        - Ryan: Conservatively agreed to invalidate votes, but OK with async approval.
+
+### Action items
+
+- Ryan: Figure out video recording meetings
+- Ryan: Send out async time coordination for meetings in the next 4 weeks.
+- Jack: What is our absent policy?
+- Ryan: check RFC for absence policy and alternates
+    - RFC does not have an absence policy, N-2 is there for *decisions*
+- Ryan will own team repo merge.
+- Mark will own RFC repo merge.
+
+### Consented Decisions
+
+- Meetings will be once a week for the time being
+    - Review once a month
+- Stream creation: one private, with history shared with new members, and one public

--- a/minutes/sync-meeting/2023-06-22.md
+++ b/minutes/sync-meeting/2023-06-22.md
@@ -1,0 +1,115 @@
+# 2023-06-22
+
+## Agenda
+
+- Check-in
+- Assign facilitator and note-taker roles
+- (turn on recording, perhaps)
+- Consent to agenda
+- Approve minutes from previous meeting
+- Enumerate time-sensitive items (**Time**: 5 Minutes)
+    - Items: 
+        - Project Directors the Foundation ((s-)elections set for July?)
+        - Formally establish trademark working group
+        - Foundation Executive Director Evaluation
+            - Foundation Board committee for evaluating ED's performance requests process for getting project input into this process
+        - Initial plan for PR responses
+    - **Goal**: ensure awareness and establish common understanding - no action in the meeting needs to take place
+- Establish location council documentation (e.g., team repo, Forge, or something else?) (**Time**: 15 minutes)
+    - Existing discussion: [[link](https://rust-lang.zulipchat.com/#narrow/stream/392734-council/topic/Home.20for.20Council.20documents)]
+    - **Goal**: decide what the location will be (at least for now and at least for Council operational decisions) and assign someone to create that location
+    - Documentation kinds (each of which may require a different location):
+        - Council operational decisions (e.g., [Council Sync Meetings Doc](https://hackmd.io/@ryanlevick/B1kVrcKD3))
+        - Council policy decisions (e.g., how does the Council make decisions?)
+        - Project policy decisions that the Council makes (e.g, Project Director to the Foundation (s)election process)
+    - **Proposal**: @ehuss [[link](https://rust-lang.zulipchat.com/#narrow/stream/392734-council/topic/Home.20for.20Council.20documents/near/367735774)]
+- Discussion on delegating work to subset of the Council (**Time**: 10 minutes)
+    - **Goal**: Decide whether delegation to subsets of the Council is the right predecesor to delegating to folks outside the Council
+        - There are two early possibilities for this:
+            - PR and Social media subgroup
+            - Project Director Selection subgroup
+- Discuss meta process for project director (s)elections (**Time**: 10 minutes)
+    - Existing discussion: [[link](https://rust-lang.zulipchat.com/#narrow/stream/392734-council/topic/Foundation.20project.20directors.20selection.2Felection)]
+    - **Goal**: decide on deadline for establishing the process and who is responsible for shepherding. 
+    - **Draft Proposal**: @yaahc [[link](https://hackmd.io/NhppYH7HTxGD9hoogVJRaw)]
+- Small follow-ups and clarifications
+- Check-out
+
+## Minutes
+
+* Ryan: Is there consensus to record, even if we end up deleting?
+  * Decision: We will delete the video within 1 week if there is no decision what to do with it.
+      * No objections raised, approved.
+* Approve minutes from previous meeting
+    * Carol: We already released last week, but we should discuss whether we do this going forward.
+    * Mark: Just noting that this document is also immediately public.
+    * Decision: For this meeting, are we ok with continuing this strategy?
+        * Mara: Objection - can we move to a temporarily private doc for this meeting too, and then publish soon after?
+        * Seconded by Mark, agreed to do this.
+* Enumerate time-sensitive items (**Time**: 5 Minutes)
+    * Ryan went over items in agenda to spread awareness amongst the council.
+    * Project director (s)elections
+        * No commentary.
+    * Trademark group
+        * Mara: Helpful context - we should make sure WGs created have explicit role as representing project vs. interested folks with no representational authority.
+        * Eric Huss: Why is this time sensitive?
+            * Ryan: The Foundation feels this is time sensitive, which we need to respond to.
+    * Foundation Executive Director Evaluation
+        * No commentary.
+    * Initial plan for Public Relations responses
+        * Khio: We will need a strategy (folks, policy, etc.) on PR responses, particularly time sensitive ones. We may need this soon.
+            * Jack: This seems similar to later discussion on decision making
+* Establish location for council documentation (e.g., team repo, Forge, or something else?) (**Time**: 15 minutes)
+    * **Proposal**: @ehuss [[link](https://rust-lang.zulipchat.com/#narrow/stream/392734-council/topic/Home.20for.20Council.20documents/near/367735774)]
+    * Ryan: There are multiple decisions and places they can go. Things can change over time, but we are already making some operational decisions, we should start putting them more permanent than hackmd docs.
+    * Eric Huss: HackMD workspace for documents + GitHub repository for the team.
+    * Ryan: Amending to put team repo as the first place we use for now, even if we move things later. Want to unblock iterating on the question of where things live.
+    * Eric Holk: GitHub repo - can we have private PRs that later become public?
+        * Jonathan: +1 to this idea.
+        * Ryan: Is this technically possible?
+        * Mara: Two repositories seems feasible.
+        * Khio: Actual PRs cannot be made public.
+    * Decision: documents into a github team repo, with hackmd for ephemeral docs.
+        * No objections to this.
+        * Volunteers: Eric Huss
+        * Ryan: Note to let infra know if additional tooling needed.
+* Discussion on delegating work to subset of the Council (**Time**: 10 minutes)
+    * Ryan: We would confer limited authority on subset of the group to make decisions. Some examples: PR/social media on behalf the council, project director selection question. Opening for short discussion.
+    * Jack: Size of group matters - I think 2 people is a good size for things coming up. Can summarize back to the group. Can make smaller decisions.
+    * Khio: Minimum of two people sounds right. Upper cap seems too contextual to be worth while. One person doing research and reporting back seems plausible though, but having two could eliminate bias concerns. I don't think we should limit to council members only - we have volunteers already!
+    * Ryan: Delegating to other groups - seems like we have broad agreement on this, but getting better at delegation in a group we already know may make sense. That said, next item on the agenda is project director selection - and Jane has been involved there. How do we ensure that the whole council is happy with the delegated groups? We need a feedback/evolution process, ideally before we run into problems.
+    * Jonathan: Two categories of delegation - "go do work and bring back a report" or delegated authority. The first of these seems lightweight, whereas the second is more cautious/harder/needs review. We should distinguish between these.
+    * Mara: Is this too general to make progress? For example, posting a single tweet vs. project directors are very different. Can we get more concrete?
+    * Ryan: Seems good to get more concrete. If no disagreement in general, then we can focus on the two items in the agenda to make decisions. Delegating authority to those within the council is easier as they already represent the project - so there may be opportunity in breaking that category into smaller parts.
+    * Khio: Making a subgroup with authority creates a change in who consents to items in the contextual scope, so it is very distinct.
+    * Khio: Would like to be a part of the group on PR(?).
+    * Mara: Spectrum of options between delegating authority and just work: for example, with Twitter, difference between re-tweeting obvious things vs. responding to PR events. r+ rights are given to many people and expected to use "correctly".
+    * Ryan: Does anyone object to the general idea of delegation within the council?
+        * No objections raised.
+    * Ryan: Do we want to establish a group on "PR/social media on behalf of the council"? i.e., they are responsible for communication from the council but not general re-tweeting from the council.
+        * Mara: Worried that the scope constrains us out of e.g. Rust release tweets.
+        * Eric Holk: Cautious about reducing approval for social things, because part of the goal for the council is to protect against accidents there. Lightweight non-controversial media seems reasonable (difficult line to draw). Some things need the full team though. Trust is important, we can trust the subteam to escalate to the whole team when needed.
+        * Khio: The point of a PR team is responsive replies - we don't have on-call commitment, so that makes it hard to rely on the full group. Doing initial mitigation quickly makes more sense. My suggestion is that the group proposes a plan for things to do, and while they do they can handle existing recurring announcements.
+        * Jack: Creating the group does not mean they need to respond, they can focus on just collecting things and own ensuring coverage. Is now the right moment to approve which things the group does?
+        * Eric Holk: 1-2 people empowered to say "We're aware and will address soon" seems ok.
+        * Ryan: Taking offline further discussion on the PR group front.
+    * Decision: Mara can tweet out blog posts released on the Rust blog.
+        * No objections.
+* Discuss meta process for project director (s)elections (**Time**: 10 minutes)
+    * Goal: rough deadline of July and who is responsible for this.
+    * Mark: Just clarifying that the extension of terms is relatively lightweight, we have done this a few more times.
+    * Mara: Also have decisions on how many folks to replace, when, etc.
+    * Ryan: Who can work on this?
+    * Mara: Experts outside the council being involved sounds great. Selecting directors is a tricky topic, particularly if wider project is involved. Maybe trickier to do quickly.
+    * Eric Holk: Who gets consulted in the selection process seems like the key question. In the interest of expediency, we may want to do a council pick for now.
+    * Carol: Decision proposal - Create a subcommittee by 2nd meeting in July to bring back a proposal on the process for selection to the council for ratification.
+        * Volunteers: Eric Holk, Ryan, Jane
+        * Eric Holk: Bringing Jane in formally is worthwhile.
+        * Mara: Including a member of the board is good.
+        * No objections.
+        * Mark: This will mean re-extending the director terms - do we have problems with that?
+        * Ryan: Next week we will decide on extension.
+* Remaining items
+    * Mara: Decisions made on this meeting - how do we put these out?
+    * Ryan: Let's just make it known as best we can in Zulip, can figure it out async and discuss in next agenda.
+* Checkout


### PR DESCRIPTION
The Council [has decided](https://rust-lang.zulipchat.com/#narrow/stream/392734-council/topic/Home.20for.20Sync.20Meeting.20Notes/near/369595603) that this repo will be the home for approved meeting minutes. 

This doesn't require full consensus from the Council as the matter has already been decided.

r? @ehuss 