### PR TITLE
Add committee docs template and librarian committee doc

### DIFF
--- a/committees/TEMPLATE.md
+++ b/committees/TEMPLATE.md
@@ -1,0 +1,42 @@
+# Leadership Council _NAME_ Committee
+
+<!--
+    This is a template for defining Leadership Council Committees.
+    The text below shows example questions that the sections should answer in a concise format preferably with links to where readers can find more information. These questions are a guide and it is not required to answer all of them.
+-->
+
+## Mission
+
+A short description of this committee's mission; what is the purpose of this committee.
+
+## Goals
+
+List the expected outcomes, such as what they are expected to accomplish. Optionally you may wish to list *non*-goals.
+
+## Delegated Responsibilities
+
+A description of what decision-making authority has been delegated to the committee, and what is expected of them.
+
+## Duration
+
+The intended duration for this committee (standing, temporary). What is its expected lifecycle?
+
+## Contact, Communication, and Workspace
+
+Where will this committee record and do its work (such as a GitHub repo, or GitHub project tracker) and where will the members communicate with each other (such as a Zulip stream)? Are there specific GitHub issue labels to track their work? 
+
+How do those outside the committee communicate with the committee? What is the best way to become involved? How can issues be raised?
+
+<!-- examples, not all is required -->
+- **Zulip Stream**: <https://rust-lang.zulipchat.com/#narrow/stream/392734-council>
+- **GitHub Repo**: <https://github.com/rust-lang/leadership-council>
+- **GitHub Labels**: <https://github.com/rust-lang/leadership-council/issues?q=is%3Aopen+label%3Alabel1%2Clabel2>
+- **GitHub Project**: <https://github.com/orgs/rust-lang/projects/1>
+
+## Process
+
+How does this committee work? Does it have meetings? Does it require consensus on all decisions? Does it present reports or recommendations to the Council? Is it required for decisions to be brought up to the Council?
+
+## Members
+
+- [Name](https://github.com/rust-lang/team/blob/master/people/username.toml)

--- a/committees/librarians.md
+++ b/committees/librarians.md
@@ -1,0 +1,56 @@
+# Leadership Council Librarians
+
+## Mission
+
+The Leadership Council Librarians are tasked with recording output of the Leadership Council (meetings, decisions, policies, guides, documentation, etc.) as well as tracking and recording work items and the Council's backlog.
+
+## Goals
+
+* Ensure the Council can easily retain and access policies, decisions, discussions, etc. for future use including by future members.
+* Make the output of the Council sufficiently accessible to the public to provide transparency and clarity to the Council's actions
+* Make information about Project Policy and internal Council operations clear to anyone inside or outside the project.
+* Make tooling available (in close collaboration with the infra team) for managing the tasks listed in [responsibilities](#delegated-responsibilities).
+
+## Delegated Responsibilities
+
+The Librarians are responsible for the following:
+
+* Recording Project policies
+* Recording and tracking Council internal operations.
+* Recording operational decisions of the Council.
+* Preservation of Council meeting minutes and other meeting artifacts.
+* Maintaining a system for tracking work items and proposals including providing an accessible overview of the work items for the Council, Rust Project members, and for the wider community.
+* Recording and tracking the existence and membership of Council Committees and other Council initiatives.
+* Ensuring Council Member membership and affiliations are recorded.
+* Tooling for tracking deadlines and time-sensitive things.
+
+Where possible, all of these items should provide up-to-date tracking of changes over time.
+
+The Librarians have the authority to make decisions over the tooling used for recording and tracking this information, with consultation with the Council.
+Smaller internal tools that are used only by the Librarians do not require consultation.
+
+## Duration
+
+The duration of the Librarian Committee is intended to be indefinite, as long as the Council finds that having individuals assigned these tasks is useful.
+Approximately every year, the Council should reevaluate and review the Librarian Committee's permit and performance.
+
+For example, if all recording tasks are sufficiently automated or diffused among the entire Council, then the Librarian Committee may be retired.
+
+## Contact, Communication, and Workspace
+
+The Librarians primarily use general Leadership Council workspaces for communication and may be contacted through them:
+
+- **Zulip Stream**: <https://rust-lang.zulipchat.com/#narrow/stream/392734-council>
+- **GitHub Repo**: <https://github.com/rust-lang/leadership-council>
+- **GitHub Labels**: <https://github.com/rust-lang/leadership-council/issues?q=is%3Aopen+label%3AC-Librarians>
+
+## Process
+
+Decisions about new systems and tooling are made by consensus of all Librarian members.
+
+The process for how specific systems are managed should be recorded in this document as new decisions are made.
+
+## Members
+
+- [Eric Huss](https://github.com/rust-lang/team/blob/master/people/ehuss.toml)
+- [Ryan Levick](https://github.com/rust-lang/team/blob/master/people/rylev.toml)


### PR DESCRIPTION
We want to start documenting the fact that many of the Council's responsibilities will be delegated out to other groups (potentially with membership composed of Council members). This is the start of this documentation.

r? @ehuss 