### PR TITLE
add charter for project director election process committee

### DIFF
--- a/committees/project-director-election-process.md
+++ b/committees/project-director-election-process.md
@@ -1,5 +1,9 @@
 # Leadership Council _Project Director Election Process_ Committee
 
+## Mission
+
+This committee is tasked to to establish the process for selecting Project Directors for the Rust Foundation to fulfill the requirements of [RFC 3392](https://rust-lang.github.io/rfcs/3392-leadership-council.html).
+
 ## Goals
 
 * Design the election process for the next set of Rust Foundation project directors (ratified by the leadership council)
@@ -8,11 +12,13 @@
 
 ## Delegated Responsibilities
 
-* None, this committee exists to create a proposal which will be consented to by the council
+* This committee decides the content of the proposal which will be presented to the council for their consent.
 
 ## Duration
 
-* Temporary. This committee may be recreated each time we do a project director election in order to help support the process.
+* Temporary
+* This committee may be recreated each time we do a project director election in order to help support the process.
+* The committee will wrap up once it has finished it's review of the process's effectiveness (estimated: 1 month post selection)
 
 ## Contact, Communication, and Workspace
 
@@ -20,8 +26,6 @@
 - **Meeting Minutes**: https://hackmd.io/@rust-leadership-council/BJANZIm_h
 
 ## Process
-
-How does this committee work? Does it have meetings? Does it require consensus on all decisions? Does it present reports or recommendations to the Council? Is it required for decisions to be brought up to the Council?
 
 * This committee tracks it's backlog within the meeting minutes hackmd document.
 * This committee works via zulip and has video meetings on an as needed basis.

--- a/committees/project-director-election-process.md
+++ b/committees/project-director-election-process.md
@@ -2,7 +2,7 @@
 
 ## Goals
 
-* Design the election process for the next set of rust foundation project directors (ratified by the leadership council)
+* Design the election process for the next set of Rust Foundation project directors (ratified by the leadership council)
 * Clearly document and communicate the process and support it’s execution
 * Track, review, and document the effectiveness of the process
 

--- a/committees/project-director-election-process.md
+++ b/committees/project-director-election-process.md
@@ -1,0 +1,34 @@
+# Leadership Council _Project Director Election Process_ Committee
+
+## Goals
+
+* Design the election process for the next set of rust foundation project directors (ratified by the leadership council)
+* Clearly document and communicate the process and support it’s execution
+* Track, review, and document the effectiveness of the process
+
+## Delegated Responsibilities
+
+* None, this committee exists to create a proposal which will be consented to by the council
+
+## Duration
+
+* Temporary. This committee may be recreated each time we do a project director election in order to help support the process.
+
+## Contact, Communication, and Workspace
+
+- **Zulip Stream**: https://rust-lang.zulipchat.com/#narrow/stream/394329-council.2Fproject-director-election-proposal
+- **Meeting Minutes**: https://hackmd.io/@rust-leadership-council/BJANZIm_h
+
+## Process
+
+How does this committee work? Does it have meetings? Does it require consensus on all decisions? Does it present reports or recommendations to the Council? Is it required for decisions to be brought up to the Council?
+
+* This committee tracks it's backlog within the meeting minutes hackmd document.
+* This committee works via zulip and has video meetings on an as needed basis.
+* This committee operates via consent, the proposal will be presented to the council once all committee members have fully reviewed the council and have no further feedback or objections.
+
+## Members
+
+* Ryan Levick ([rylev](https://github.com/rust-lang/team/blob/master/people/rylev.toml))
+* Eric Holk ([eholk](https://github.com/rust-lang/team/blob/master/people/eholk.toml))
+* Jane Losare-Lusby ([yaahc](https://github.com/rust-lang/team/blob/master/people/yaahc.toml))

--- a/committees/project-director-election-process.md
+++ b/committees/project-director-election-process.md
@@ -25,7 +25,7 @@ How does this committee work? Does it have meetings? Does it require consensus o
 
 * This committee tracks it's backlog within the meeting minutes hackmd document.
 * This committee works via zulip and has video meetings on an as needed basis.
-* This committee operates via consent, the proposal will be presented to the council once all committee members have fully reviewed the council and have no further feedback or objections.
+* This committee operates via consent, the proposal will be presented to the council once all committee members have fully reviewed the proposal and have no further feedback or objections.
 
 ## Members
 

--- a/committees/project-director-election-process.md
+++ b/committees/project-director-election-process.md
@@ -3,7 +3,7 @@
 ## Goals
 
 * Design the election process for the next set of Rust Foundation project directors (ratified by the leadership council)
-* Clearly document and communicate the process and support it’s execution
+* Clearly document and communicate the process and support its execution
 * Track, review, and document the effectiveness of the process
 
 ## Delegated Responsibilities


### PR DESCRIPTION
I removed the "Mission" section because I wasn't sure what to put there that wasn't a duplicate of the goals. No objections to adding it back if someone wants to suggest some wording.

* [rendered](https://github.com/yaahc/leadership-council/blob/main/committees/project-director-election-process.md)