### PR TITLE
Propose process for tracking events

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ The GitHub issue tracker at <https://github.com/rust-lang/leadership-council/iss
 
 [`procedures/issues.md`]: https://github.com/rust-lang/leadership-council/blob/main/procedures/issues.md
 
+### Schedule tracking
+
+The calendar of upcoming events and deadlines is tracked in <https://hackmd.io/@rust-leadership-council/H1bb7yPs2>. More information about schedule tracking may be found in [`procedures/schedule.md`].
+
+[`procedures/schedule.md`]: https://github.com/rust-lang/leadership-council/blob/main/procedures/schedule.md
+
+
 ## License
 
 Content in this repository is licensed under the [MIT license](LICENSE-MIT) and the [Apache license 2.0](LICENSE-APACHE).

--- a/procedures/schedule.md
+++ b/procedures/schedule.md
@@ -1,0 +1,21 @@
+# Council Schedule Tracking
+
+The Council maintains a document at <https://hackmd.io/@rust-leadership-council/H1bb7yPs2> to track upcoming and recurring events and deadlines.
+Any Council member is free to add new events to the schedule.
+
+## Review
+
+Any upcoming events that require synchronous discussion or awareness should be added to the council meeting agenda for the next upcoming meeting. Upcoming events should be reviewed at the start of every synchronous council meeting. Anything that seems to be at risk should be highlighted, possibly adjusting dates if needed, or calling for participation if they cannot be adjusted.
+
+All Council members are responsible for keeping the schedule up-to-date, but ultimately the Librarians are responsible for managing the list.
+
+## Required triggers
+
+Some actions by the Council should automatically trigger a new entry to the schedule. The exact time frame depends on the specific situation, with some rough suggestions listed here, but should be adjusted based on the event and what is expected of the followup.
+
+- A new, one-time process may elect to have an evaluation after the process is over and there has been some time for the effects of the process to play out. For example, the Foundation Project Director Selection process may decide to have a review 1 month after the decisions have been carried out to evaluate how well the process went, and to provide feedback to the participants. It is recommended to keep this within a timeframe where the event is still fresh in everyone's mind.
+- Any policy change should schedule an evaluation of that change.
+    - Policies that have been recently adjusted or called into question should have shortened evaluation periods to ensure they're iterating towards stability more quickly.
+    - Shorter evaluations should be in the 3 to 6 month time frame.
+    - Longer evaluations, perhaps for minor changes, or changes that take more time to play out, may consider a 1 year evaluation.
+- Formation of new committees should have a review of that how well that committee is working approximately 6 months after the formation, or sooner if the committee completed their work more quickly. Afterwards, committees should then be reviewed annually for feedback and to verify that the committee still needs to exist.

--- a/templates/sync-meeting-agenda.md
+++ b/templates/sync-meeting-agenda.md
@@ -4,6 +4,7 @@
 - Assign roles
 - Turn on recording
 - Announcements
+    - Highlight any upcoming deadlines that need attention
 - Consent to agenda
 - Agenda Item 1 (*Champion's Name* **Time**: $N Minutes)
     - **Goal**:  

--- a/templates/sync-meeting-agenda.md
+++ b/templates/sync-meeting-agenda.md
@@ -4,7 +4,7 @@
 - Assign roles
 - Turn on recording
 - Announcements
-    - Highlight any upcoming deadlines that need attention
+    - Highlight any upcoming deadlines that need attention <https://hackmd.io/@rust-leadership-council/H1bb7yPs2>
 - Consent to agenda
 - Agenda Item 1 (*Champion's Name* **Time**: $N Minutes)
     - **Goal**:  


### PR DESCRIPTION
This is a proposal for tracking events and deadlines for the Council.

Basically, just keep a list in hackmd that we review and track.
I picked hackmd just to keep the friction down.
This was briefly discussed at https://rust-lang.zulipchat.com/#narrow/stream/392734-council/topic/Tracking.20deadlines.20and.20time-sensitive.20items.
