### PR TITLE
Un-redact meeting minutes

### DIFF
--- a/minutes/sync-meeting/2023-08-03.md
+++ b/minutes/sync-meeting/2023-08-03.md
@@ -7,8 +7,42 @@
 - Turn on recording
 - Announcements
 - Consent to agenda
-- Private Moderation Team Issue (*Eric Huss* **Time**: 20 Minutes)
-    - **Note**: redacted from the minutes
+- COI and Moderation Team (*Eric Huss* **Time**: 20 Minutes)
+    - **Goal**: Decide on public announcement?
+    - **Goal**: Discuss how to resolve the COI.
+    - **Goal**: Discuss if there is any support we can give for growing the moderation team.
+    * Eric: Initial question: who/what is the COI? RFC does not address the specific circumstances here, with only one other member of the team available. Is there opportunity for growth that could also solve this problem?
+    * Public announcement
+        * Ryan: Let's inform Khio on what timeline we want to set. More about someone new joining.
+        * Jonathan: Perhaps we can have a standard post that we write for all such situations.
+        * JoshG: Khio is also stepping down from mod team. Probably ought to be simultaneous across multiple things...
+            * Ryan: Moderation team increase now ought to be top priority.
+    * Staffing mods
+        * JoshG: No known volunteers at this time for new mods.
+        * Mara: Recent application from Amos
+            * Not followed up on.
+    * Carol: Is there a need to say that we're not making decisions while the COI exists?
+    * Mark: So, what is the COI?
+        * JoshG: Futurewei
+        * Mara: Is this a conflict?
+            * JoshG: Maybe Jack?
+        * Ryan: Let's figure this out async (read RFC, confirm COI, etc.)
+    * Jonathan: We should have a formal declaration of interests (private)
+    * Mara: Let's make sure to not accidentally publish.
+    * Eric Huss: For now, Josh can avoid voting.
+        * Carol: Which means that for this meeting we lack quorum.
+    * Ryan: Who will own blog post?
+        * Carol volunteers
+    * Eric: How do we go about resolving the conflict, if it exists? Get N conflicting people together to talk?
+        * Ryan: Sounds reasonable. Another option is to avoid representation from mods.
+    * Eric: When and where do we continue discussion of growing mod team?
+        * Ryan: I can own something soon
+        * Mara: having only 1 mod feels like it ought to be a top priority, i.e., drop the rest of the agenda...
+        * JoshG: Plus, council becomes un-moderatable too.
+        * Ryan: I don't feel productive talking about it immediately.. but we should start immediately thereafter.
+   * Jonathan: Let's reach out to Amos perhaps?
+       * Josh: I can reach out to Amos
+       * Jonathan: Let's also figure out if we can go to 3 and then down to 2.
 - 2024 Edition (*Eric Huss* **Time**: 5 minutes)
     - **Goal**: Poll to check for any objections for an intent to have a 2024 edition and to form a working group.
     - **Goal**: Poll to check any objections to using an RFC to start this process. 

--- a/minutes/sync-meeting/2023-08-14.md
+++ b/minutes/sync-meeting/2023-08-14.md
@@ -53,8 +53,16 @@ Unavailable: JP, Khio
   - Ryan: I think we can start drafting blog now, we can parallelize final sign off with that.
   - Eric Holk: My plan is to kick off drafting the blog post etc. today.
 - Private moderation team issue (*Ryan Levick* **Time**: 5 Minutes)
-    - **Goal**: Ensure clarity on next steps including path for public disclosure
-    - **This topic is temporarily private, and will be published in the future once it is no longer private.**
+  - **Goal**: Ensure clarity on next steps including path for public disclosure
+  - Ryan: No concerns yet expressed.
+  - Mark: Have we resolved the concern around moderation of council members given no other moderators who are independent?
+      - Ryan: I think we should prioritize getting more moderators, this seems OK.
+          - +1s from Eric Holk, Mara
+      - Mark: But, the situation here *is* unique. The RFC is specific that the moderator on the council recuses themselves from actions involving the council.
+  - Mark: I think we need to publicly state/acknowledge the problem prior to announcement/formal approval, but otherwise we should move forward here.
+      - Eric Holk: +1 to that public announcement.
+      - Mark will own making sure this is included in the post.
+  - Ryan: Carol is drafting the announcement text, goal is end of week having path forward.
 - Assign sub-groups for high priorities (*Eric Huss* **Time**: 15 Minutes)
     - **Goal**: Determine who will focus on each of the top three priorities.
         1. Documenting and improving processes for interaction with the Rust Foundation.


### PR DESCRIPTION
These topics were temporarily withheld because they involved something that had not yet been announced. It has since been announced (https://blog.rust-lang.org/inside-rust/2023/08/29/leadership-council-membership-changes.html and other places), so this can now be included in the public minutes.