### PR TITLE
Add policy for determining Project Director substitutes

### DIFF
--- a/policies/project-directorship/board-meeting-substitutes.md
+++ b/policies/project-directorship/board-meeting-substitutes.md
@@ -8,10 +8,8 @@ The Rust project, however, sets the following policy for how a substitute for a 
 
 * The Project Director should inform the other Project Directors and the Council of their absence as soon as possible preferably at least 7 days before the Foundation board meeting will take place.
 * The absence of the Project Director may be announced publicly.
-* Any Project Director or Council member may nominate any Project member who would otherwise be eligible to be a Project Director (with limited exceptions[^demo-exception]).
-* The substitute is chosen by consensus among the Project Directors and Council members.
+* Any Project Director or Council member may nominate any Project member in good standing who would otherwise be eligible to be a Project Director (as defined by Foundation by-laws or other Council policies with limited exceptions [^demo-exception]).
+* The substitute is chosen by consensus[^consensus] among the Project Directors and Council members.
 * If consensus cannot be reached the default is to not send any substitute.
 
-The following are considerations that may limit whether someone is eligible to be a 
-
-[demo-exception]: For purposes of substitutions, a person is allowed to be a substitute even if their presence would violate a restriction on the demographic makeup of the Project Directors group. For example, if policy forbids Project Directors from sharing the same employer, a substitute may be allowed even if they share an employer with an existing Project Director. This allows for as wide of a substitute pool as possible. A necessary consequence of allowing this is that some people who are eligible to be substitutes will in turn not be eligible to be permanent Project Directors. Therefore, if possible, substitutes whose presence does not violate demographic restrictions should be preferred.
+[demo-exception]: For purposes of substitutions, a person is allowed to be a substitute even if their presence would violate a policy restriction on the demographic makeup of the Project Directors group. For example, if policy forbids Project Directors from sharing the same employer, a substitute may be allowed even if they share an employer with an existing Project Director. This allows for as wide of a substitute pool as possible. A necessary consequence of allowing this is that some people who are eligible to be substitutes will in turn not be eligible to be permanent Project Directors. Therefore, if possible, substitutes whose presence does not violate demographic restrictions should be preferred.

--- a/policies/project-directorship/board-meeting-substitutes.md
+++ b/policies/project-directorship/board-meeting-substitutes.md
@@ -8,6 +8,10 @@ The Rust project, however, sets the following policy for how a substitute for a 
 
 * The Project Director should inform the other Project Directors and the Council of their absence as soon as possible preferably at least 7 days before the Foundation board meeting will take place.
 * The absence of the Project Director may be announced publicly.
-* Any Project Director or Council member may nominate any Project member as a potential substitute unless the member has an open moderation sanction against them.
+* Any Project Director or Council member may nominate any Project member who would otherwise be eligible to be a Project Director (with limited exceptions[^demo-exception]).
 * The substitute is chosen by consensus among the Project Directors and Council members.
 * If consensus cannot be reached the default is to not send any substitute.
+
+The following are considerations that may limit whether someone is eligible to be a 
+
+[demo-exception]: For purposes of substitutions, a person is allowed to be a substitute even if their presence would violate a restriction on the demographic makeup of the Project Directors group. For example, if policy forbids Project Directors from sharing the same employer, a substitute may be allowed even if they share an employer with an existing Project Director. This allows for as wide of a substitute pool as possible. A necessary consequence of allowing this is that some people who are eligible to be substitutes will in turn not be eligible to be permanent Project Directors. Therefore, if possible, substitutes whose presence does not violate demographic restrictions should be preferred.

--- a/policies/project-directorship/board-meeting-substitutes.md
+++ b/policies/project-directorship/board-meeting-substitutes.md
@@ -1,0 +1,13 @@
+# Rust Foundation Board Meeting Substitutes
+
+The [Rust Foundation bylaws](https://foundation.rust-lang.org/policies/bylaws) do not give any instructions on how a substitute for a Project Director who cannot make a Foundation Board meeting should be selected. Only the following is state in section 4.3(h):
+
+> Each Director may designate in writing or by electronic transmission to the Chairperson or Secretary (which designation may be withdrawn in writing at any time by such Director or Member) an individual to act as a Director in their stead, whether for a single meeting or as a standing alternate. Any such alternate Director shall be entitled to (i) attend and vote at all meetings which the designating Director does not attend, (ii) sign all written consents in lieu of the designating Director, and (iii) otherwise exercise the duties and enjoy the privileges of the designating Director in the absence or unavailability of the designating Director; provided, however, that no such alternate Director may propose a vote or vote upon any Committee of the Board.
+
+The Rust project, however, sets the following policy for how a substitute for a Project Director is determined:
+
+* The Project Director should inform the other Project Directors and the Council of their absence as soon as possible preferably at least 7 days before the Foundation board meeting will take place.
+* The absence of the Project Director may be announced publicly.
+* Any Project Director or Council member may nominate any Project member as a potential substitute unless the member has an open moderation sanction against them.
+* The substitute is chosen by consensus among the Project Directors and Council members.
+* If consensus cannot be reached the default is to not send any substitute.

--- a/policies/project-directorship/election-process.md
+++ b/policies/project-directorship/election-process.md
@@ -4,7 +4,7 @@
 
 The purpose of this policy is to outline a clear and efficient process for electing new Project Directors to represent the Rust project on the board of the Rust Foundation. The process aims to achieve the following goals:
 
-* Select candidates who fulfill the outlined candidate criteria in the [role description document](../roles/rust-foundation-project-director.md), focusing on new leadership and diverse perspectives rather than solely prioritizing the best candidate.
+* Select candidates who fulfill the outlined candidate criteria in the [role description document](../../roles/rust-foundation-project-director.md), focusing on new leadership and diverse perspectives rather than solely prioritizing the best candidate.
     * Strive for tolerance and inclusivity by prioritizing selecting candidates that everyone can accept over selecting the first choice for only a subset of people.
 * Conduct the selection process in a time-efficient manner.
 * Incorporate input from a wide range of stakeholders across the entire Rust project.


### PR DESCRIPTION
This solves an ambiguity about what to do when a Project Director cannot make a Foundation Board meeting. Instead of there being UB where in practice the PD in question decided on their own, this document lies out a simple procedure for choosing a sub. 

Supersedes #61 

@ehuss can you kick off the review process again and check off those who have already given their checkmark?