### PR TITLE
Add a guide for new Council Representatives.

### DIFF
--- a/guides/new-representative-guide.md
+++ b/guides/new-representative-guide.md
@@ -55,3 +55,14 @@ An existing Council member will help add you to:
 
 [resources]: ../README.md#resources
 [team repo]: https://github.com/rust-lang/team/blob/master/teams/leadership-council.toml
+
+## Communicating with subteams
+
+An important task for a Representative is to communicate with the people you represent.
+This can be challenging if you represent a large number of teams, with people spanning many timezones, and using different communication tools.
+
+A good first step is to figure out the best way to communicate with your subteams, whether that be via email lists, chat tools like Zulip or Discord, or to drop in on synchronous meetings on video meeting tools like Jitsi.
+It would be good to introduce yourself, and to let people know how best to contact you.
+
+Over time, you will need to send information to the team members you represent, or to solicit feedback.
+The more you can communicate and be visible with your team members, the better you will be able to represent their needs to the Council and maintain connections across the project.

--- a/guides/new-representative-guide.md
+++ b/guides/new-representative-guide.md
@@ -1,0 +1,57 @@
+# New Council Representative Guide
+
+Welcome to the Rust Leadership Council!
+This guide is an introduction in what you can expect to do as a Representative and how to get started.
+
+The previous Council Representative for your team should be able to answer any questions you have and hand off any responsibilities, and inform you of any ongoing work.
+
+## Background information
+
+Before you get started, it would be good to read the [Council Representative Role description][role] and the [Council Policy document][policy] which defines what the Council is and what authority it has.
+That should give you a general idea of what will be expected of you.
+
+[role]: ../roles/council-representative.md
+[policy]: https://forge.rust-lang.org/governance/council.html
+
+## How the Council operates
+
+There are several different aspects of how you actually carry out the activities of the Council.
+
+- The Council meets every other week over a video chat for one hour to make announcements, have discussions, and make decisions.
+  See [synchronous meetings] for more information.
+- Most discussion takes place on [Zulip].
+  There are several private streams which you will be invited to when you join (but please try to use the public streams as much as possible).
+- The Council tracks its tasks in the [issue tracker].
+  See [issue tracking] for how that works.
+- The Council forms [committees] which are a way to delegate authority or to coordinate initiatives.
+  Committee membership is not restricted to Representatives; any Project member may join.
+  However, this often requires close interaction with the Council, so the committees benefit from Council member participation.
+  If you are interested in helping with any existing or future initiatives, let the other members know.
+- The Council uses a consensus model for making internal decisions, where everyone needs to agree without blocking concerns.
+  These are usually done during the synchronous meeting, Zulip polls, or GitHub via rfcbot.
+  Public decisions use the RFC process for making policy changes.
+- There will be occasional private requests sent to the `council@rust-lang.org` mailing list.
+  You will need to work with the other Council members to decide on how to respond.
+- There will be occasional private discussions with the Foundation Project Directors and the Foundation staff.
+  These usually happen on Zulip or some other chat like Jitsi.
+
+[synchronous meetings]: ../procedures/synchronous-meetings.md
+[Zulip]: ../README.md#zulip
+[issue tracker]: https://github.com/rust-lang/leadership-council/issues
+[issue tracking]: ../procedures/issues.md
+[committees]: ../committees/
+
+## Council resources
+
+Check out the [resources] list for the tools and services the Council uses.
+An existing Council member will help add you to:
+
+- The [team repo] to formally add you to the Council.
+  This will also add you to the GitHub team, Zulip group, and the email list.
+  If possible, it is recommended that you add the `council@rust-lang.org` address to skip spam filtering, since we currently do not have a spam filter, many providers will send all content to spam.
+- The public and private Zulip streams.
+- The HackMD team workspace.
+- The synchronous meetings (Google Meet).
+
+[resources]: ../README.md#resources
+[team repo]: https://github.com/rust-lang/team/blob/master/teams/leadership-council.toml


### PR DESCRIPTION
This adds a guide to help orient new Council Representatives.

Closes #26
Closes #28
(I don't feel inclined to automate any of this, thus the checklist at the bottom should suffice for now.)
