### PR TITLE
Add representative selection process guide.

### DIFF
--- a/guides/representative-selection.md
+++ b/guides/representative-selection.md
@@ -1,6 +1,6 @@
 # Representative selection process
 
-This document is a guide for the selection of Representatives for the Leadership Council. This gives recommendations for how a top-level team should select their Representative. It is not a requirement that teams follow this guide; teams may choose their own process.
+This document is a guide for the selection of Representatives for the Leadership Council. This gives recommendations for how a top-level team should select their Representative. It is not a requirement that teams follow this guide; top-level teams may choose their own process.
 
 This process is inspired by the [Sociocracy selection process](https://www.sociocracyforall.org/selection-process/).
 

--- a/guides/representative-selection.md
+++ b/guides/representative-selection.md
@@ -1,8 +1,8 @@
 # Representative selection process
 
-This document is a guide for the selection of Representatives for the Leadership Council. This gives recommendations for how a top-level team should select their Representative. It is not a requirement that teams follow this guide, and may choose their own process.
+This document is a guide for the selection of Representatives for the Leadership Council. This gives recommendations for how a top-level team should select their Representative. It is not a requirement that teams follow this guide; teams may choose their own process.
 
-This process is inspired by the [Sociacracy selection process](https://www.sociocracyforall.org/selection-process/).
+This process is inspired by the [Sociocracy selection process](https://www.sociocracyforall.org/selection-process/).
 
 ## Recommendations on candidate choice
 
@@ -10,7 +10,7 @@ See [candidate criteria] for guidance for choosing a candidate. See [representat
 
 Many of the same qualities that make a good Council representative also make a good team lead. However, we strongly recommend against individuals taking on both the role of team lead and Council representative simultaneously. In the past, our experience has shown that it is extremely difficult to balance the demands of both roles effectively. For teams with shared leadership responsibilities (e.g. co-leads), assigning one co-lead as the representative may be fine if the other co-lead(s) are prepared to take on more of the team leadership responsibilities. However, for teams with a single lead, we recommend either establishing multiple clearly delineated team leadership roles or selecting a different Council representative.
 
-Remember that Council representatives can be subteam members, if a subteam member has the requisite scope and skillset.
+Remember that Council representatives can be members of a subteam[^subteam], if a member has the requisite scope and skillset.
 
 It is recommended to rotate Representatives when possible. The extra responsibilities of being a Representative *and* participating as a team member can push people closer to burnout. It is also important to spread the experience across more people, which can help bring new ideas and perspectives, and help bring a better understanding of how the Rust Project works to more people.
 
@@ -44,7 +44,7 @@ Representative selection should ideally be done by consensus, not by vote or sim
     - Continue the process of seeking consensus and addressing objections until a satisfactory candidate is selected.
         - Note that this process seeks to produce a candidate everyone is satisfied with and has no objections to. Avoid lengthy debates over preferences that do not pertain to objections or unmet requirements.
 7. Report the choice to the Leadership Council.
-    - The Council is responsible for validating that the new Council composition does not exceed the [affiliation limits]. If there is an exceedance, see the given link for the process of restarting the selection process.
+    - The Council is responsible for validating that the new Council composition does not exceed the [affiliation limits]. If there is an exceedance, see the affiliation limits link for the process of restarting the selection process.
 
 [affiliation limits]: https://forge.rust-lang.org/governance/council.html#limits-on-representatives-from-a-single-companyentity
 
@@ -58,3 +58,5 @@ It is recommended to give the selection process roughly four to six weeks to com
 3. Week 3: Collect any objections to the nominee, and attempt to resolve them.
 4. Week 4: Report your final choice to the Council.
     - This may require collaboration to resolve any affiliation limits.
+
+[^subteam]: Throughout this document, “teams” includes subteams, working groups, project groups, initiatives, and all other forms of official collaboration structures within the Project. “Subteams” includes all forms of collaboration structures that report up through a team.

--- a/guides/representative-selection.md
+++ b/guides/representative-selection.md
@@ -1,0 +1,60 @@
+# Representative selection process
+
+This document is a guide for the selection of Representatives for the Leadership Council. This gives recommendations for how a top-level team should select their Representative. It is not a requirement that teams follow this guide, and may choose their own process.
+
+This process is inspired by the [Sociacracy selection process](https://www.sociocracyforall.org/selection-process/).
+
+## Recommendations on candidate choice
+
+See [candidate criteria] for guidance for choosing a candidate. See [representative role] for a description of what a Representative is expected to do.
+
+Many of the same qualities that make a good Council representative also make a good team lead. However, we strongly recommend against individuals taking on both the role of team lead and Council representative simultaneously. In the past, our experience has shown that it is extremely difficult to balance the demands of both roles effectively. For teams with shared leadership responsibilities (e.g. co-leads), assigning one co-lead as the representative may be fine if the other co-lead(s) are prepared to take on more of the team leadership responsibilities. However, for teams with a single lead, we recommend either establishing multiple clearly delineated team leadership roles or selecting a different Council representative.
+
+Remember that Council representatives can be subteam members, if a subteam member has the requisite scope and skillset.
+
+It is recommended to rotate Representatives when possible. The extra responsibilities of being a Representative *and* participating as a team member can push people closer to burnout. It is also important to spread the experience across more people, which can help bring new ideas and perspectives, and help bring a better understanding of how the Rust Project works to more people.
+
+[candidate criteria]: https://forge.rust-lang.org/governance/council.html#candidate-criteria
+[representative role]: https://github.com/rust-lang/leadership-council/blob/676d7f18723fead5994019dd15bea5fb5c4062e0/roles/council-representative.md
+
+## Consensus based selection
+
+Representative selection should ideally be done by consensus, not by vote or similar. The process is roughly:
+
+1. Select a facilitator by consent:
+    - Any team member can suggest a facilitator or volunteer themselves.
+    - The facilitator must not be a candidate for the Council representative, and must be someone everyone trusts to set aside their preferences during the selection process.
+    - If there are concerns over a facilitator that cannot be resolved, it is recommended to talk to a Council member or the mod team.
+2. Request nominations from the team and subteams:
+    - The facilitator should send a message to all team members to kick off the selection process. They may want to consider sharing the recommendations [listed above](#recommendations-on-candidate-choice) for what makes a good choice.
+    - Facilitator asks for nominations, including self-nominations.
+    - Nominations should be accompanied by supporting reasoning.
+    - Anyone can share concerns about nominees privately with the facilitator or other trusted team members or the mod team, but objections happen later in the process.
+3. Discuss the nominated candidates:
+    - Team members have the opportunity to discuss nominations.
+    - Nominations can be withdrawn or added during this time.
+4. Facilitator proposes a candidate:
+    - Based on gathered data, the facilitator suggests a candidate they believe is likely to receive the group's consent.
+5. Seek objections to the facilitator's proposal:
+    - Team members can provide objections, which may be submitted privately to the facilitator if desired. Members may also ask that their objections be kept anonymous. Members may also reach out to the moderation team if they want help with submitting anonymous feedback or need other assistance.
+6. Finalize representative selection:
+    - Discuss and attempt to resolve any objections, if possible.
+    - If the proposed candidate has no remaining objections, select them as the Council representative.
+    - If objections persist and the current proposal reaches an impasse, the facilitator should make a new proposal based on the discussion and feedback received.
+    - Continue the process of seeking consensus and addressing objections until a satisfactory candidate is selected.
+        - Note that this process seeks to produce a candidate everyone is satisfied with and has no objections to. Avoid lengthy debates over preferences that do not pertain to objections or unmet requirements.
+7. Report the choice to the Leadership Council.
+    - The Council is responsible for validating that the new Council composition does not exceed the [affiliation limits]. If there is an exceedance, see the given link for the process of restarting the selection process.
+
+[affiliation limits]: https://forge.rust-lang.org/governance/council.html#limits-on-representatives-from-a-single-companyentity
+
+## Selection timeline
+
+It is recommended to give the selection process roughly four to six weeks to complete. The following is a suggested timeline:
+
+1. Week 1: Start selection process.
+    - Choose a facilitator.
+2. Week 2: Collect nominations, and discuss any concerns.
+3. Week 3: Collect any objections to the nominee, and attempt to resolve them.
+4. Week 4: Report your final choice to the Council.
+    - This may require collaboration to resolve any affiliation limits.


### PR DESCRIPTION
This adds a guide to suggest how teams may carry out their council representative selection process. This is largely taken from https://github.com/rust-lang/rfcs/pull/3392#issuecomment-1505697944, with various small edits.

Closes #25
