### PR TITLE
More detail about Project Director requirements

### DIFF
--- a/roles/rust-foundation-project-director.md
+++ b/roles/rust-foundation-project-director.md
@@ -2,6 +2,13 @@
 
 Please refer to [Rust Foundation Director Roles & Responsibilities][director-role] for components of the role description that apply to all Foundation Board Directors.
 
+Project Directors are members of the Rust Foundation Board of Directors.
+The Board of Directors is the governing body of the Rust Foundation, which is incorporated as a 501(c)(6) organization in the State of Delaware, United States of America.
+As such, the Project Director role carries with it legal responsibilities to act on behalf of and in support of the Foundation.
+
+The Board of Directors sets the direction of the Rust Foundation.
+Among the mechanisms the Board has to do this is hiring and overseeing the Executive Director, who is responsible for the day-to-day operations of the Foundation.
+
 ## Goals
 
 - Represent the needs and interests of the Rust Project at large within the Rust Foundation board
@@ -26,8 +33,25 @@ Please refer to [Rust Foundation Director Roles & Responsibilities][director-rol
 - A keen sense of the needs of Rust Project, its teams, processes, and ecosystem.
 - Willingness to understand and represent viewpoints they may not have personal experience with or necessarily agree with.
 
+## Requirements and Eligibility
+
+There are requirements and eligibility criteria Project Directors must meet.
+These are set by the Rust Project, the [Foundation bylaws], the laws of the State of Delaware, and the laws of the United States of America.
+
+- Project directors must disclose their name on the Foundation's IRS Form 990, which is a public document. For an example, see [the Foundations 2021 filing][form-990].
+- A candidate may not be elected as a Project Director if they are employed by a corporate member of the Foundation that already employs another Project Director.
+  This comes from [Section 4.3(g)] of the Foundation bylaws.
+
+  In the past there has been confusion about the definition of employment.
+  Thus far the Project and Foundation have used a fairly broad definition that includes contracting relationships.
+- Project Directors must disclose any conflicts of interest to the Foundation.
+  These disclosures are kept confidential by the Foundation and are not shared with the public.
+
 ## Term Length
 
 - 2 year term
 
 [director-role]: https://foundation.rust-lang.org/static/board-director-role-description.pdf
+[Foundation bylaws]: https://foundation.rust-lang.org/policies/bylaws/#article-iv%3A-directors
+[form-990]: https://foundation.rust-lang.org/static/publications/financial-filings/form-990-2021.pdf
+[Section 4.3(g)]: https://foundation.rust-lang.org/policies/bylaws/#section-4.3-nomination%2C-election-and-term-of-office-of-directors:~:text=No%20person%20may%20be%20elected%20Project%20Director%20if%2C%20at%20the%20time%20of%20election%2C%20that%20person%20is%20employed%20by%20a%20Corporate%20Member%20and%20that%20Corporate%20Member%20or%20any%20Related%20Company%20already%20employs%20a%20Project%20Director.

--- a/roles/rust-foundation-project-director.md
+++ b/roles/rust-foundation-project-director.md
@@ -38,12 +38,14 @@ Among the mechanisms the Board has to do this is hiring and overseeing the Execu
 There are requirements and eligibility criteria Project Directors must meet.
 These are set by the Rust Project, the [Foundation bylaws], the laws of the State of Delaware, and the laws of the United States of America.
 
+- Project directors must be members of the Rust Project in good standing.
+  Among other things, this means they must not be currently under any moderation sanction.
 - Project directors must disclose their name on the Foundation's IRS Form 990, which is a public document. For an example, see [the Foundations 2021 filing][form-990].
 - A candidate may not be elected as a Project Director if they are employed by a corporate member of the Foundation that already employs another Project Director.
   This comes from [Section 4.3(g)] of the Foundation bylaws.
 
-  In the past there has been confusion about the definition of employment.
   Thus far the Project and Foundation have used a fairly broad definition that includes contracting relationships.
+  This is in line with Delaware corporate law, where the key element of how "employment" is defined is that an individual is engaged to carry out work or services for the company.
 - Project Directors must disclose any conflicts of interest to the Foundation.
   These disclosures are kept confidential by the Foundation and are not shared with the public.
 
@@ -54,4 +56,4 @@ These are set by the Rust Project, the [Foundation bylaws], the laws of the Stat
 [director-role]: https://foundation.rust-lang.org/static/board-director-role-description.pdf
 [Foundation bylaws]: https://foundation.rust-lang.org/policies/bylaws/#article-iv%3A-directors
 [form-990]: https://foundation.rust-lang.org/static/publications/financial-filings/form-990-2021.pdf
-[Section 4.3(g)]: https://foundation.rust-lang.org/policies/bylaws/#section-4.3-nomination%2C-election-and-term-of-office-of-directors:~:text=No%20person%20may%20be%20elected%20Project%20Director%20if%2C%20at%20the%20time%20of%20election%2C%20that%20person%20is%20employed%20by%20a%20Corporate%20Member%20and%20that%20Corporate%20Member%20or%20any%20Related%20Company%20already%20employs%20a%20Project%20Director.
+[Section 4.3(g)]: https://foundation.rust-lang.org/policies/bylaws/#section-4.3-nomination%2C-election-and-term-of-office-of-directors

--- a/roles/rust-foundation-project-director.md
+++ b/roles/rust-foundation-project-director.md
@@ -41,7 +41,7 @@ These are set by the Rust Project, the [Foundation bylaws], the laws of the Stat
 - Project directors must be members of the Rust Project in good standing.
   Among other things, this means they must not be currently under any moderation sanction.
 - Project directors must disclose their name on the Foundation's IRS Form 990, which is a public document. For an example, see [the Foundations 2021 filing][form-990].
-- A candidate may not be elected as a Project Director if they are employed by a corporate member of the Foundation that already employs another Project Director.
+- No two project directors can be employed by the same corporate member of the Foundation.
   This comes from [Section 4.3(g)] of the Foundation bylaws.
 
   Thus far the Project and Foundation have used a fairly broad definition that includes contracting relationships.

--- a/roles/rust-foundation-project-director.md
+++ b/roles/rust-foundation-project-director.md
@@ -4,10 +4,12 @@ Please refer to [Rust Foundation Director Roles & Responsibilities][director-rol
 
 Project Directors are members of the Rust Foundation Board of Directors.
 The Board of Directors is the governing body of the Rust Foundation, which is incorporated as a 501(c)(6) organization in the State of Delaware, United States of America.
-As such, the Project Director role carries with it legal responsibilities to act on behalf of and in support of the Foundation.
+As such, the Project Director role carries with it legal responsibilities to act on behalf of and in support of the Foundation, as well as some legal liability for the Foundation's actions[^liability].
 
 The Board of Directors sets the direction of the Rust Foundation.
 Among the mechanisms the Board has to do this is hiring and overseeing the Executive Director, who is responsible for the day-to-day operations of the Foundation.
+
+[^liability]: While this sounds daunting, the Foundation has insurance to protect the Directors from legal action brought against the faction. As long as Directors carry out their board duties in good faith, to the best of the abilities, and with the best interests of the Foundation in mind, they are protected by this insurance.
 
 ## Goals
 


### PR DESCRIPTION
There are a number of legal and other eligibility requirements for Project Directors. These have caused significant confusion during passed elections, so we want to at least document the status quo.

The edits here attempt to clarify the requirements and how we've interpreted them in practice, as well as provide more background on the fact that some of them are rooted in the Foundation's legal responsibilities.

Issue #66