### PR TITLE
Add observer guidelines for sharing

### DIFF
--- a/procedures/meeting-observers.md
+++ b/procedures/meeting-observers.md
@@ -30,6 +30,12 @@ Intentional disruption of the meeting will result in an observer being kicked fr
 
 It is expected that, by default, those joining as meeting observers will follow the above guidelines. However, there may be times where the council will invite guests to participate beyond the role and guidelines of meeting observers. This may happen ahead of the meeting time or, at the discretion of the meeting participants, during the meeting itself. Under these circumstances, adherence to meeting observer guidelines is not expected.
 
+### Discretion
+
+Observers may share what they observe in the meeting.
+They must use discretion, recognizing that sensitive issues may be discussed even in public sessions.
+It should be made clear that the things they share are their own observations and not official statements of or on behalf of the council.
+
 ## Alternatives
 
 ### Extending meeting observers to non-Project members

--- a/procedures/meeting-observers.md
+++ b/procedures/meeting-observers.md
@@ -34,7 +34,11 @@ It is expected that, by default, those joining as meeting observers will follow 
 
 Observers may share what they observe in the meeting.
 They must use discretion, recognizing that sensitive issues may be discussed even in public sessions.
+People in meetings are speaking freely and words taken out of context can lead to misunderstandings.
 It should be made clear that the things they share are their own observations and not official statements of or on behalf of the council.
+Observers might want to consider using the [Chatham House Rule] (that is, summarizing what is said without attributing it to a specific person) when sharing meeting observations.
+
+[Chatham House Rule]: https://en.wikipedia.org/wiki/Chatham_House_Rule
 
 ## Alternatives
 

--- a/procedures/meeting-observers.md
+++ b/procedures/meeting-observers.md
@@ -36,9 +36,6 @@ Observers may share what they observe in the meeting.
 They must use discretion, recognizing that sensitive issues may be discussed even in public sessions.
 People in meetings are speaking freely and words taken out of context can lead to misunderstandings.
 It should be made clear that the things they share are their own observations and not official statements of or on behalf of the council.
-Observers might want to consider using the [Chatham House Rule] (that is, summarizing what is said without attributing it to a specific person) when sharing meeting observations.
-
-[Chatham House Rule]: https://en.wikipedia.org/wiki/Chatham_House_Rule
 
 ## Alternatives
 


### PR DESCRIPTION
The previous policy did not make it clear what, if anything, observers could share from meetings. This commit attempts to clarify the policy by explicitly allowing observers to share observations but requesting care in what is shared and how it's shared.