### PR TITLE
Add policy for the 2024 experimental travel grants

### DIFF
--- a/policies/spending/travel.md
+++ b/policies/spending/travel.md
@@ -1,0 +1,34 @@
+# Travel spending policy
+
+The Leadership Council of the Rust Project has allocated up to $75,000 USD to be spent over the course of 2024 supporting Members of the Rust Project in attending Rust-related events through the awarding of Travel Grants. These grants are intended to cover travel, hotel, and event tickets for those who otherwise cannot afford to attend. This document sets out the policy for what is allowed for these grants, and the process for the approval of these applications.
+
+Note that this policy is currently experimental. These guidelines may change at any time, as we are currently evaluating the effectiveness of this policy. As we gain experience, we hope to extend this as an ongoing program in the future.
+
+## Approval guidelines
+
+The following are guidelines for approval of an application:
+
+- Up to $2000 per person (per year) (as long as budget remains).
+- You don't have an employer that can pay for you.
+- You are an active member of the Rust project.
+- Your travel costs are kept to a reasonable minimum (i.e. fly economy class, no five star hotels, etc.).
+
+The usual Foundation due diligence on grantees will also be required to ensure compliance with US sanctions, proper record-keeping, anti-fraud measures, etc.
+
+### Automatic approval
+
+In order to reduce the overhead of processing applications, the Foundation will automatically approve applications with the following guidelines:
+
+- The applicant is a Member of the Rust Project (as defined by being on the “All At” mailing list).
+- The event is considered to be legitimate. Whilst there is no definition of a “formal” Rust event, it should be one that is broadly known within the Rust Community and considered to be of value.
+- The amount being sought does not exceed $1,000 USD AND, if awarded, the total amount awarded to that individual including earlier travel grants, should they exist, does not exceed $1,000 USD over the course of a calendar year. The amounts should seem reasonable given the applicant's place of residence and the location of the event itself.
+
+Applications outside of these guidelines will be sent to the Leadership Council for approval.
+
+## Process
+
+To apply, send an email to <mailto:grants@rustfoundation.org> with an estimation of the budget you need, what event you need it for, and a brief note on why you need it so we can learn and come up with a good policy in the future. After approval, the Foundation will reimburse the actual costs of your trip (up to the approved limit).
+
+## Transparency
+
+As with all the Foundation’s grants programs, the Foundation will have to maintain complete and accurate records of its grantees in order to report to the IRS. Aggregate statistics on the number of travel grants awarded, the number of recipients, and the number of events attended as a result will also be published as part of the Foundation’s annual report. The list of recipients of travel grants and the amounts received will be available on request.

--- a/policies/spending/travel.md
+++ b/policies/spending/travel.md
@@ -2,7 +2,7 @@
 
 The Leadership Council of the Rust Project has allocated up to $75,000 USD to be spent over the course of 2024 supporting Members of the Rust Project in attending Rust-related events through the awarding of Travel Grants. These grants are intended to cover travel, hotel, and event tickets for those who otherwise cannot afford to attend. This document sets out the policy for what is allowed for these grants, and the process for the approval of these applications.
 
-Note that this policy is currently experimental. These guidelines may change at any time, as we are currently evaluating the effectiveness of this policy. As we gain experience, we hope to extend this as an ongoing program in the future.
+Note that this policy is currently experimental (see <https://github.com/rust-lang/leadership-council/issues/97>). These guidelines may change at any time, as we are currently evaluating the effectiveness of this policy. As we gain experience, we hope to extend this as an ongoing program in the future.
 
 ## Approval guidelines
 

--- a/policies/spending/travel.md
+++ b/policies/spending/travel.md
@@ -31,4 +31,6 @@ To apply, send an email to <mailto:grants@rustfoundation.org> with an estimation
 
 ## Transparency
 
-As with all the Foundation’s grants programs, the Foundation will have to maintain complete and accurate records of its grantees in order to report to the IRS. Aggregate statistics on the number of travel grants awarded, the number of recipients, and the number of events attended as a result will also be published as part of the Foundation’s annual report. The list of recipients of travel grants and the amounts received will be available on request.
+As with all the Foundation’s grants programs, the Foundation will have to maintain complete and accurate records of its grantees in order to report to the [IRS]. Aggregate statistics on the number of travel grants awarded, the number of recipients, and the number of events attended as a result will also be published as part of the Foundation’s annual report. The list of recipients of travel grants and the amounts received will be available on request.
+
+[IRS]: https://www.irs.gov/

--- a/policies/spending/travel.md
+++ b/policies/spending/travel.md
@@ -21,7 +21,7 @@ In order to reduce the overhead of processing applications, the Foundation will 
 
 - The applicant is a Member of the Rust Project (as defined by being on the “All At” mailing list).
 - The event is considered to be legitimate. Whilst there is no definition of a “formal” Rust event, it should be one that is broadly known within the Rust Community and considered to be of value.
-- The amount being sought does not exceed $1,000 USD AND, if awarded, the total amount awarded to that individual including earlier travel grants, should they exist, does not exceed $1,000 USD over the course of a calendar year. The amounts should seem reasonable given the applicant's place of residence and the location of the event itself.
+- The amount being sought does not exceed $1000 USD AND, if awarded, the total amount awarded to that individual including earlier travel grants, should they exist, does not exceed $1000 USD over the course of a calendar year. The amounts should seem reasonable given the applicant's place of residence and the location of the event itself.
 
 Applications outside of these guidelines will be sent to the Leadership Council for approval.
 

--- a/policies/spending/travel.md
+++ b/policies/spending/travel.md
@@ -11,7 +11,7 @@ The following are guidelines for approval of an application:
 - Up to $2000 per person (per year) (as long as budget remains).
 - You don't have an employer that can pay for you.
 - You are an active member of the Rust project.
-- Your travel costs are kept to a reasonable minimum (i.e. fly economy class, no five star hotels, etc.).
+- Your travel costs are kept reasonable (i.e. fly economy class, no five star hotels, etc.).
 
 The usual Foundation due diligence on grantees will also be required to ensure compliance with US sanctions, proper record-keeping, anti-fraud measures, etc.
 


### PR DESCRIPTION
This writes down the policy that we previously agreed upon for the travel grants we are awarding in 2024. This is based on the email sent to all@ in May, and the proposal from Paul for streamlining the process.
