### PR TITLE
Switch HackMD team link to a public link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The Council has synchronous meetings to discuss topics and make decisions. See [
 
 ### HackMD
 
-The Council has a public HackMD workspace at <https://hackmd.io/team/rust-leadership-council>. This workspace provides a home for Council members to collaborate and create draft documents. More permanent documentation should go in this repository or the Rust Forge.
+The Council has a public HackMD workspace at <https://hackmd.io/@rust-leadership-council> (Council members can manage the workspace at <https://hackmd.io/team/rust-leadership-council>). This workspace provides a home for Council members to collaborate and create draft documents. More permanent documentation should go in this repository or the Rust Forge.
 
 Since this HackMD workspace is using the free service, it does not support private documents. If you need to draft a private document, create it in your personal workspace and use private channels to share the link.
 


### PR DESCRIPTION
This updates the link to the HackMD team to include the public link. Although my intentions with this documentation was aimed at council members, it makes sense to make it easier for everyone else to see the documents. I don't particularly like how HackMD makes these two different pages, but it is what it is.

Closes #106