### PR TITLE
Add clarifications around definition of employment

### DIFF
--- a/roles/rust-foundation-project-director.md
+++ b/roles/rust-foundation-project-director.md
@@ -20,6 +20,10 @@ Among the mechanisms the Board has to do this is hiring and overseeing the Execu
 
 - 2-5 hours per week
 
+## Term Length
+
+- 2 year term
+
 ## Tasks / Activities / Responsibilities
 
 - [Abide by the Roles & Responsibilites of Foundation Board Members](https://foundation.rust-lang.org/static/board-director-role-description.pdf)
@@ -44,16 +48,23 @@ These are set by the Rust Project, the [Foundation bylaws], the laws of the Stat
   Among other things, this means they must not be currently under any moderation sanction.
 - Project directors must disclose their name on the Foundation's IRS Form 990, which is a public document. For an example, see [the Foundations 2021 filing][form-990].
 - No two project directors can be employed by the same corporate member of the Foundation.
-  This comes from [Section 4.3(g)] of the Foundation bylaws.
-
-  Thus far the Project and Foundation have used a fairly broad definition that includes contracting relationships.
-  This is in line with Delaware corporate law, where the key element of how "employment" is defined is that an individual is engaged to carry out work or services for the company.
+  This comes from [Section 4.3(g)] of the Foundation bylaws. See [Employment interpretation](#employment-interpretation).
 - Project Directors must disclose any conflicts of interest to the Foundation.
   These disclosures are kept confidential by the Foundation and are not shared with the public.
 
-## Term Length
+### Employment interpretation
 
-- 2 year term
+The definition of *employment* is deliberately left a little open to interpretation in order to apply a principle/spirit of the rules approach to situations as they arise, rather than trying to anticipate every possible scenario and potentially tie future issues up in unintended knots.
+
+The Project and Foundation use a fairly broad definition of employment that includes contracting relationships. This is in line with Delaware corporate law, where the key element of how "employment" is defined is that an individual is engaged to carry out work or services for the company.
+
+The purpose of the limit of seats per company on the board is to mitigate real or perceived disproportionate corporate influence. If a substantial and/or ongoing proportion of your income is received from one company, this affiliation should be disclosed, as it may (or may be seen to) tilt the board in favor of one company.
+
+We do not have a hard and fast number for the income threshold for disclosing as a contractor. Arguments can be made for/against almost any number, and we could disappear down a rabbit hole trying to make rules that apply to every individuals' financial circumstances. We don't want to be over-the-top, and we certainly don't want to get into a "prove your income" scenario. Our hope is that candidates take a sensible, err on the side of disclosure approach, looking at their income and asking: "realistically, if I do not disclose this affiliation, but it comes out later, will the wider community interpret that as a deliberate act of concealment / a way of gaining corporate influence by stealth" etc. This is not only to protect the Foundation's reputation, it is to protect the reputation of the PDs and the companies that they act for. Transparency is an important principle of the Foundation, and we hope that anyone considering taking a prominent role governing the Foundation would want to lean in to that.
+
+If you have contracts that include discretion or nondisclosure agreements, and those may be considered a conflict of interest, please consult with the Foundation.
+
+Employment information is disclosed to the Leadership Council. When elected, the Foundation will ask new PDs to register their financial interests and sign a conflict of interest policy. Wherever there is a conflict of interest in a board meeting, conflicted individuals will be required to step out of that conversation. It would be noted in the minutes that an individual stepped out due to a conflict, but it is not necessary to state what that conflict is. We do not publish PDs affiliations on the website.
 
 [director-role]: https://foundation.rust-lang.org/static/board-director-role-description.pdf
 [Foundation bylaws]: https://foundation.rust-lang.org/policies/bylaws/#article-iv%3A-directors


### PR DESCRIPTION
Closes #66

This adds some text further clarifying how we interpret employment for PDs. This is a copy of what Bec provided at https://rust-lang.zulipchat.com/#narrow/stream/392734-council/topic/Project.20Director.20Employment.2FAffiliation/near/393905005, edited mostly for clarity and brevity.

I think this is useful context and details to have, which should hopefully clear up any of the uncertainty we've had (despite being intentionally vague).
