### PR TITLE
Remove "experimental" status of the travel grant policy

### DIFF
--- a/policies/spending/travel.md
+++ b/policies/spending/travel.md
@@ -1,8 +1,8 @@
 # Travel spending policy
 
-The Leadership Council of the Rust Project has allocated up to $75,000 USD to be spent over the course of 2024 supporting Members of the Rust Project in attending Rust-related events through the awarding of Travel Grants. These grants are intended to cover travel, hotel, and event tickets for those who otherwise cannot afford to attend. This document sets out the policy for what is allowed for these grants, and the process for the approval of these applications.
+The Leadership Council of the Rust Project has allocated up to $75,000 USD to be spent each year supporting Members of the Rust Project in attending Rust-related events through the awarding of Travel Grants. These grants are intended to cover travel, hotel, and event tickets for those who otherwise cannot afford to attend. This document sets out the policy for what is allowed for these grants, and the process for the approval of these applications.
 
-Note that this policy is currently experimental (see <https://github.com/rust-lang/leadership-council/issues/97>). These guidelines may change at any time, as we are currently evaluating the effectiveness of this policy. As we gain experience, we hope to extend this as an ongoing program in the future.
+We plan to continue this program as long as funds are available. An announcement will be made if this program is discontinued, or if there are significant changes to it.
 
 ## Approval guidelines
 


### PR DESCRIPTION
This drops the "experimental" status of the travel grant program. For the most part I think we have been happy with how it has worked. As much as we are able to, I think we would like to continue this program in the coming years.

Closes https://github.com/rust-lang/leadership-council/issues/97
