### PR TITLE
Update steps for new directors to add to team database

### DIFF
--- a/policies/project-directorship/election-process.md
+++ b/policies/project-directorship/election-process.md
@@ -72,8 +72,10 @@ The election meeting is comprised of all members of the Leadership Council who w
     * Verifying eligibility.
     * Onboarding new directors.
     * Announcing the new directors ([example](https://foundation.rust-lang.org/news/announcing-the-rust-foundation-s-newest-project-director-carol-nichols/)).
-* A council member should update the private Zulip channel membership (`council-project-directors/private`).
-* A council member should arrange to update the director Zulip group `@foundation-project-directors`.
+* A council member should help with:
+    * Update the private Zulip channel membership (`council-project-directors/private`).
+    * Update the director Zulip group `@foundation-project-directors`.
+    * Update the [`foundation-board-project-directors`](https://github.com/rust-lang/team/blob/master/teams/foundation-board-project-directors.toml) marker team.
 
 If for some reason the Council is unable to reach consensus on a group of
 candidates (for example, the Council finds blocking objections to all


### PR DESCRIPTION
This updates the director election steps to also update the team just added in https://github.com/rust-lang/team/pull/1620.