### PR TITLE
Snapshot budget/spending into this repository

### DIFF
--- a/policies/spending/budget.md
+++ b/policies/spending/budget.md
@@ -1,0 +1,38 @@
+# Council budget tracking
+
+This file tracks a snapshot of the Council's budget allocations and is updated periodically.
+
+## 2025
+
+Total: $325,000
+
+| Category                | Reserved | Spent     |
+|-------------------------|----------|-----------|
+| Travel[^travel]         |  $75,000 |   $79,673 |
+| Rust week tickets       |          |   $10,207 |
+| Program manager[^pm]    | $240,000 |        $0 |
+
+Travel remaining: $43,965
+Total spent: $306,608
+Total reserved of $650,000: $600,000
+Total unreserved: $50,000
+
+[^pm]: https://github.com/rust-lang/leadership-council/issues/151
+
+## 2024
+
+Total: $325,000
+
+| Category                | Reserved | Spent     |
+|-------------------------|----------|-----------|
+| Travel[^travel]         |  $75,000 |   $13,632 |
+| Rust leads summit       |          |    $2,523 |
+| All-hands[^all]         | $100,000 |  $100,000 |
+| Project grants[^grants] |  $80,000 |   $80,000 |
+| Compiler ops[^ops]      |  $30,000 |   $20,573 |
+| Unreserved              |  $40,000 |        $0 |
+
+[^travel]: https://github.com/rust-lang/leadership-council/blob/HEAD/minutes/sync-meeting/2024-04-12.md
+[^all]: https://github.com/rust-lang/leadership-council/blob/main/minutes/sync-meeting/2024-07-19.md
+[^grants]: https://github.com/rust-lang/leadership-council/issues/112
+[^ops]: https://github.com/rust-lang/leadership-council/issues/114


### PR DESCRIPTION
This snapshots the hackmd so we have a more durable record that's also read-only for linking from the survey (and other content).

I opted to put this in the policies folder since it feels like it's basically a policy, but open to other options there.

r? @ehuss 