### PR TITLE
Add Rust Foundation Maintainer Fund Design committee

### DIFF
--- a/committees/maintainer-fund-design-group.md
+++ b/committees/maintainer-fund-design-group.md
@@ -51,7 +51,7 @@ The members of the committee will be given access to the results of the Rust Pro
 
 - [Lori Lorusso](https://rust-lang.org/governance/people/LoriLorusso)
   - As a representative of the Rust Foundation, which manages the Fund.
-- [Jack Huey](https://rust-lang.org/governance/people/jackh726/)
+- [Niko Matsakis](https://rust-lang.org/governance/people/nikomatsakis/)
 - [lcnr](https://rust-lang.org/governance/people/lcnr)
 - [kobzol](https://rust-lang.org/governance/people/Kobzol)
 - [tmandry](https://rust-lang.org/governance/people/tmandry)


### PR DESCRIPTION
This PR proposes a LC subcommittee for preparing an RFC that will guide the workings of the Rust Foundation Maintainer Fund (https://rust-lang.zulipchat.com/#narrow/channel/392734-council/topic/how.20we.20decide.20how.20to.20structure.20the.20maintainer.20fund/with/558720734).

The members of this subcommittee will not have any special privileges or voting rights. They are simply tasked by the Council to talk to various stakeholders, explore the design space of the Rust Foundation Maintainer Fund, and prepare an RFC.