### PR TITLE
project directors: responsibilities

### DIFF
--- a/roles/rust-foundation-project-director.md
+++ b/roles/rust-foundation-project-director.md
@@ -8,9 +8,9 @@ The Board of Directors sets the direction of the Rust Foundation. Among the mech
 
 [^directors]: Please refer to [Rust Foundation Director Roles & Responsibilities] for components of the role description that apply to all Foundation Board Directors.
 [^liability]: While this sounds daunting, the Foundation has insurance to protect the Directors from legal action brought against the faction. As long as Directors carry out their board duties in good faith, to the best of their abilities, and with the best interests of the Foundation in mind, they are protected by this insurance.
-[^establishment]: The Project Directors specifically are established by the [Section 4.3(d)] of the Foundation's By-laws to represent the "Individual Members" of the Foundation. Individual members are defined as those in "the governing body of the Rust project" ([Section 2.2]), currently the Leadership Council.
+[^establishment]: The Project Directors specifically are established by the [Section 4.3(d)] of the Foundation's Bylaws to represent the "Individual Members" of the Foundation. Individual members are defined as those in "the governing body of the Rust project" ([Section 2.2]), currently the Leadership Council.
 
-    By analogy, Project Directors are to the Leadership Council what Google's Platinum Member Director is to Google, in the sense that they represent the Council's (and by extension the Project's) interests in the Rust Foundation. Although it should be noted the Rust Project is distinct from member organizations of the Rust Foundation, as the Foundation exists explicitly to serve the Rust Project, but does not exist to serve its member organisations (outwith stipulations of membership)
+    By analogy, Project Directors are to the Leadership Council what Google's Platinum Member Director is to Google, in the sense that they represent the Council's (and by extension the Project's) interests in the Rust Foundation. Although it should be noted the Rust Project is distinct from member organizations of the Rust Foundation, as the Foundation exists explicitly to serve the Rust Project, but does not exist to serve its member organisations (without specific membership stipulations)
 
 In addition to their responsibilities to the Rust Foundation, Project Directors have responsibilities within the Rust Project, primarily ensuring the Project's relationship with Rust Foundation is healthy and productive.
 
@@ -29,7 +29,7 @@ In addition to their responsibilities to the Rust Foundation, Project Directors 
 
 ## Tasks / Activities / Responsibilities
 
-Project Directors are delegated responsibility for the Project's relationship with the Foundation, ensuring that it is well-functioning and that primarily the Project's needs of the Foundation, but also the Foundation's needs of the Project are met.
+Project Directors are delegated responsibility for the Project's relationship with the Foundation, ensuring that it is well-functioning and that, primarily, the Project's needs of the Foundation, but also the Foundation's needs of the Project, are met.
 
 As the Leadership Council has the authority to speak as the Project, it is vital that the Project Directors regularly communicate with the Leadership Council and act in accordance with what they genuinely believe to be the will of the Leadership Council and therefore of the Project. Regular communication is required between the Leadership Council and Project Directors. In the event of larger discussions related to the Foundation's efforts, the Project Directors and Leadership Council are expected to work together to establish a consistent and coherent position that the Project Directors are then entrusted to deliver to the Foundation and guide in its implementation.
 
@@ -52,7 +52,7 @@ In summary, Project Directors are..
   - Publishing summaries of Foundation board meetings for the Project.
   - Meeting with the Foundation staff on a regular basis.
   - Acting in the best interests of the Rust Foundation, as required of Directors by Delaware law.
-  - Maintaining a familiarity with the By-laws of the Rust Foundation.
+  - Maintaining a familiarity with the Bylaws of the Rust Foundation.
   - Abiding by the [Rust Foundation Director Roles & Responsibilities].
 
 - **..accountable to:** the Leadership Council
@@ -68,9 +68,9 @@ In summary, Project Directors are..
 - **..expected to keep informed:** the Leadership Council and broader project membership
 
   - It is vital that the Leadership Council are informed of the actions of the Project Directors and of the ongoing work and priorities of the Foundation.
-  - By working closely with the Foundation staff and voting in board meetings, the Project Directors can ensure that the Foundation's work aligns with the best interests of the Project, and so should communicate to the project membership what the Foundation is doing and how it is benefits the Rust project.
+  - By working closely with the Foundation staff and voting in board meetings, the Project Directors can ensure that the Foundation's work aligns with the best interests of the Project, and so should communicate to the Project membership what the Foundation is doing and how it is benefits the Rust Project.
 
-In order for the Project Directors to be successful in their role, the Leadership Council are..
+In order for the Project Directors to be successful in their role, the Leadership Council are...
 
 - **..expected to consult:** the Project Directors
   - Project Directors are expected to be able to communicate the needs of and constraints on the Foundation as relevant to any ongoing discussions (or to find out)
@@ -79,7 +79,7 @@ In order for the Project Directors to be successful in their role, the Leadershi
   - Project Directors should be aware of any interactions with the Foundation which are relevant to the Project Directors performing their responsibilities effectively
   - Project Directors should be informed of relevant items for the "Project Director Update" in board meetings
 
-Similarly, the Foundation staff are..
+Similarly, the Foundation staff are...
 
 - **..accountable to:** the Project Directors
   - As board members of the Foundation, the Project Directors are members of the highest leadership body of the Foundation
@@ -98,7 +98,7 @@ Similarly, the Foundation staff are..
 ## Requirements and Eligibility
 
 There are requirements and eligibility criteria Project Directors must meet.
-These are set by the Rust Project, the [Foundation By-laws], the laws of the State of Delaware, and the laws of the United States of America.
+These are set by the Rust Project, the [Foundation Bylaws], the laws of the State of Delaware, and the laws of the United States of America.
 
 - Project directors must be members of the Rust Project in good standing.
   Among other things, this means they must not be currently under any moderation sanction.
@@ -118,13 +118,13 @@ The purpose of the limit of seats per company on the board is to mitigate real o
 
 We do not have a hard and fast number for the income threshold for disclosing as a contractor. Arguments can be made for/against almost any number, and we could disappear down a rabbit hole trying to make rules that apply to every individuals' financial circumstances. We don't want to be over-the-top, and we certainly don't want to get into a "prove your income" scenario. Our hope is that candidates take a sensible, err on the side of disclosure approach, looking at their income and asking: "realistically, if I do not disclose this affiliation, but it comes out later, will the wider community interpret that as a deliberate act of concealment / a way of gaining corporate influence by stealth" etc. This is not only to protect the Foundation's reputation, it is to protect the reputation of the PDs and the companies that they act for. Transparency is an important principle of the Foundation, and we hope that anyone considering taking a prominent role governing the Foundation would want to lean in to that.
 
-If you have contracts that include discretion or non-disclosure agreements, and those may be considered a conflict of interest, please consult with the Foundation.
+If you have contracts that include discretion or nondisclosure agreements, and those may be considered a conflict of interest, please consult with the Foundation.
 
 Employment information is disclosed to the Leadership Council. When elected, the Foundation will ask new PDs to register their financial interests and sign a conflict of interest policy. Wherever there is a conflict of interest in a board meeting, conflicted individuals will be required to step out of that conversation. It would be noted in the minutes that an individual stepped out due to a conflict, but it is not necessary to state what that conflict is. We do not publish PDs affiliations on the website.
 
 [Rust Foundation Director Roles & Responsibilities]: https://rustfoundation.org/wp-content/uploads/2023/12/board-director-role-description.pdf
 [Foundation's IRS Form 990 for 2023]: https://rustfoundation.org/resource/form-990-2023/
-[Foundation By-laws]: https://foundation.rust-lang.org/policies/bylaws/#article-iv%3A-directors
+[Foundation Bylaws]: https://foundation.rust-lang.org/policies/bylaws/#article-iv%3A-directors
 [Section 2.2]: https://rustfoundation.org/policy/bylaws/#section-2.2-conditions-of-membership
 [Section 4.3(d)]: https://rustfoundation.org/policy/bylaws/#section-4.3-nomination%2C-election-and-term-of-office-of-directors
 [Section 4.3(g)]: https://foundation.rust-lang.org/policies/bylaws/#section-4.3-nomination%2C-election-and-term-of-office-of-directors


### PR DESCRIPTION
cc #230 #41

The responsibilities of the Project Directors are unclear and leave a lot of ambiguity:

- Who is ultimately responsible for the Project's relationship with the Foundation?
- What decisions can the PDs make independently of consultation with the LC?
- Who should the Foundation contact to understand the position of the Rust Project?
- What are the LC's expectations of the PDs?
- Who should the Foundation listen to if the PDs disagree with the LC?
  - The LC are the governing body of the Rust project so ultimately determine the project's view, but as board members, the PDs are the highest leadership body of the Foundation, so who takes priority?
- Do the PDs have any responsibilities within the Rust project?

The Foundation needs clear and coherent communication from the Rust project in order to effectively respond to the Project's needs. Ambiguity in the responsibility for the Project's communication with the Foundation, and between the PDs and LC, increases the risk of miscommunication, misunderstanding, and distrust.

Given the broad remit of the LC, the varied operations of the Rust Foundation and many responsibilities of the PDs: it is not practical for the LC to be directly involved in all of the decisions which must be made by PDs, or for PDs to consult the LC on every decision made.

Some decisions are simply too in-the-weeds or unrelated to the Project to require involvement of the LC, for example: PDs could be asked to provide feedback to the Foundation on their proposed requirements for associate membership - an important issue but one where PDs could be
entrusted to act independently in line with their best judgement and understanding of the LC's priorities and views.

Feedback or decisions may be requested of PDs during board meetings where it simply isn't possible for the PDs to ask the LC and where they must be entrusted to act independently.

However, there are larger items that will unfold over the course of several board meetings, such as how best to support maintainers, where it will be appropriate for the PDs to consult and include the LC.

As PDs are frequently experienced project members with varied and diverse backgrounds, the Project can benefit most from this collected experience when PDs are empowered as delegates of the LC.

Per previous leadership council meetings and draft proposals, this PR updates the role description of the PD role to elaborate on the responsibilities of the Project Directors. Additionally, it increases the expected time commitment of future PDs (existing PDs ought to be grandfathered in) as the current expectation is not sufficient to effectively perform the role.

This is based on a previous draft from #230 that was reviewed by some of the LC and PDs.

Closes #230