### PR TITLE
Add minutes for the 2025-12-05 meeting

### DIFF
--- a/minutes/sync-meeting/2025-12-05.md
+++ b/minutes/sync-meeting/2025-12-05.md
@@ -116,7 +116,7 @@ TC: I filed a concern to leave room for us to discuss how we want to handle that
 
 oli: What was the actual concern that was new? What were the problems this was causing?
 
-TC: He felt the discussions were coming from a very particular point of view: there were a lot of analogies being made at how Huwawei worked and he was the only one pushing against that coming from a different place.
+TC: He felt the discussions were coming from a very particular point of view: there were a lot of analogies being made at how Huawei worked and he was the only one pushing against that coming from a different place.
 
 oli: Fair, but I don't think lcnr or Jakub were affected by that much, but I could see the others feeling that way
 


### PR DESCRIPTION
After this is merged I'll post a short summary to [#council > Meeting minutes &amp; summaries](https://rust-lang.zulipchat.com/#narrow/channel/392734-council/topic/Meeting.20minutes.20.26.20summaries/with/561198432).