### PR TITLE
Raise travel grant limit to $100,000 for 2026

### DIFF
--- a/policies/spending/travel.md
+++ b/policies/spending/travel.md
@@ -1,6 +1,6 @@
 # Travel spending policy
 
-The Leadership Council of the Rust Project has allocated up to $75,000 USD to be spent each year supporting Members of the Rust Project in attending Rust-related events through the awarding of Travel Grants. These grants are intended to cover travel, hotel, and event tickets for those who otherwise cannot afford to attend. This document sets out the policy for what is allowed for these grants, and the process for the approval of these applications.
+The Leadership Council of the Rust Project has allocated up to $100,000 USD to be spent each year supporting Members of the Rust Project in attending Rust-related events through the awarding of Travel Grants. These grants are intended to cover travel, hotel, and event tickets for those who otherwise cannot afford to attend. This document sets out the policy for what is allowed for these grants, and the process for the approval of these applications.
 
 We plan to continue this program as long as funds are available. An announcement will be made if this program is discontinued, or if there are significant changes to it.
 


### PR DESCRIPTION
During 2025, we spent over $115,000 on the travel grant program. We had decided it was OK to go over budget since we spent so little of it in 2024 and we also felt that the 10th-anniversary all-hands was very important. However, I think it indicates that we need to increase our limit for 2026.

Importantly, the Foundation will have a separate $50,000 budget specifically for RustConf.

It is difficult to estimate the expected usage over the next year. For example, the all-hands may be significantly different than last year. However, I think this amount represents a good target.