### PR TITLE
Raise automatic travel grant to $2000

### DIFF
--- a/policies/spending/travel.md
+++ b/policies/spending/travel.md
@@ -21,7 +21,7 @@ In order to reduce the overhead of processing applications, the Foundation will 
 
 - The applicant is a Member of the Rust Project (as defined by being on the “All At” mailing list).
 - The event is considered to be legitimate. Whilst there is no definition of a “formal” Rust event, it should be one that is broadly known within the Rust Community and considered to be of value.
-- The amount being sought does not exceed $1000 USD AND, if awarded, the total amount awarded to that individual including earlier travel grants, should they exist, does not exceed $1000 USD over the course of a calendar year. The amounts should seem reasonable given the applicant's place of residence and the location of the event itself.
+- The amount being sought does not exceed $2000 USD AND, if awarded, the total amount awarded to that individual including earlier travel grants, should they exist, does not exceed $2000 USD over the course of a calendar year. The amounts should seem reasonable given the applicant's place of residence and the location of the event itself.
 
 Applications outside of these guidelines will be sent to the Leadership Council for approval.
 


### PR DESCRIPTION
When we initially set up the travel grant system, we kept the Council in the loop in making decisions because we wanted to carefully monitor how the budget is being spent, and to evaluate if we need to make decisions or changes. We then later added an automatic approval system with the Foundation staff responsible for ensuring the requests are reasonable. However, we still kept the automatic approvals at a lower limit.

As we have gained experience, I think it is reasonable at this time to raise the automatic approval limit to match the maximum per-person per-year limit. Particularly with the higher costs of the All-Hands, many members ended up going over the $1,000 cap (which we temporarily raised in https://github.com/rust-lang/leadership-council/issues/148).

In 2025, this appears to be about 49 people exceeding the $1,000 limit, and about 8 people going under.

Note that there was still a relatively large number of people that went over the $2,000 limit (about 23). This proposal does not cover raising the $2,000 limit. I don't know if we should stick to that amount or not, but it should probably be decided on separate from this.