### PR TITLE
Record $25k allocation for Outreachy

### DIFF
--- a/budget/budget.dat
+++ b/budget/budget.dat
@@ -181,3 +181,8 @@
 2026-01-31 Program management payments
   liabilities:payables  $11,076.51
   assets:program-management
+
+2026-02-23 Outreachy 2026 allocation
+  ; https://github.com/rust-lang/leadership-council/issues/264
+  assets:mentors  $25,000
+  assets:council


### PR DESCRIPTION
On 2026-02-23, we decided to allocate $25k to the Mentors team for the Project to participate in Outreachy in 2026.  Let's record that allocation.

- https://github.com/rust-lang/leadership-council/issues/264

cc @ehuss