### PR TITLE
Create `outreachy` subaccount in Mentors budget

### DIFF
--- a/budget/budget.dat
+++ b/budget/budget.dat
@@ -184,5 +184,5 @@
 
 2026-02-23 Outreachy 2026 allocation
   ; https://github.com/rust-lang/leadership-council/issues/264
-  assets:mentors  $25,000
+  assets:mentors:outreachy  $25,000
   assets:council


### PR DESCRIPTION
In making the allocation to the Mentors team for participation in Outreachy, we were (I believe) meaning to make an allocation to fund a specific program rather than broadly delegating this budget to the Mentors team.  E.g., if the Outreachy program cost us less than $25k, we'd (I think) expect the remainder to be returned rather than reallocated to other Mentors team activities.  So let's track this allocation more specifically with a subaccount of Mentors dedicated to this.

(Thanks to @ehuss for pointing this out.)

cc @ehuss
