### PR TITLE
Fund the Content team (2026 allocation)

### DIFF
--- a/budget/budget.dat
+++ b/budget/budget.dat
@@ -244,6 +244,6 @@
   expenses:travel  $5,915.76  ; 1 x All Hands, 1 x All Hands + RustWeek, 1 x Rust in Paris, 1 x Rust Nation UK.
   assets:travel:committed
 
-2026-03-27 Content team 2026 allocation
+2026-04-20 Content team 2026 allocation
   assets:content  $15,000
   assets:council

--- a/budget/budget.dat
+++ b/budget/budget.dat
@@ -243,3 +243,7 @@
   ; now paid after receiving expense documentation.
   expenses:travel  $5,915.76  ; 1 x All Hands, 1 x All Hands + RustWeek, 1 x Rust in Paris, 1 x Rust Nation UK.
   assets:travel:committed
+
+2026-03-27 Content team 2026 allocation
+  assets:content  $15,000
+  assets:council


### PR DESCRIPTION
In [rust-lang/leadership-council#206](https://github.com/rust-lang/leadership-council/issues/206), we chartered the Content team to work "to produce attractive publishable content for the benefit of the Rust Project, its members, and its community."

As we resolved at the time:

> Publishing attractive content educates and informs both those within our Project and those within our wider community.  It helps the Project to serve more people, to serve people better, and to attract more talent into the Project itself.

Since its chartering in August 2025, the team has recorded 19 interviews across two events — RustConf 2025 and Kangrejos 2025 — and has published 9 of those to the [RustVideos](https://www.youtube.com/@RustVideos) YouTube channel, with a 10th due out next week:

| Interviewee | Topic | Published | Link |
|---|---|---|---|
| Jan David Nose | Rust infrastructure | 2025-09-16 | [YouTube](https://www.youtube.com/watch?v=r7i-2wHtNjw), [blog post](https://blog.rust-lang.org/2025/11/25/interview-with-jan-david-nose/) |
| Yuri Astrakhan | Rust at Rivian; MapLibre | 2025-10-24 | [YouTube](https://www.youtube.com/watch?v=MgGsZmBNLO0) |
| Jack Huey & Niko Matsakis | Rust Vision Doc | 2025-10-31 | [YouTube](https://www.youtube.com/watch?v=8iQN49ktdBo) |
| Christian Legnitto | Rust + GPUs; Vectorware | 2025-11-13 | [YouTube](https://www.youtube.com/watch?v=monOq_uHHcg) |
| Benno Lossin | Field projections; Rust for Linux | 2025-11-21 | [YouTube](https://www.youtube.com/watch?v=S5fEF7Rdw28) |
| Bart Massey | Rust + education + embedded | 2025-12-05 | [YouTube](https://www.youtube.com/watch?v=-o8W6wcJlBY) |
| Taylor Cramer | C++/Rust interop; Crubit | 2026-01-26 | [YouTube](https://www.youtube.com/watch?v=eUTsOWbOHeY) |
| Daniel Almeida | Tyr; Linux GPU kernel driver in Rust | 2026-03-02 | [YouTube](https://www.youtube.com/watch?v=rgjTPBRae6I) |
| Tyler Mandry | C++/Rust interop; Glide | 2026-03-25 | [YouTube](https://www.youtube.com/watch?v=wzDESESJH8A) |

Another 9 recordings are in the pipeline — being edited or awaiting editing — including an interview with Linux kernel maintainer Greg Kroah-Hartman.

The team has done all of this as volunteers, using personal equipment (members have purchased their own microphones, cameras, lighting, etc.), editing on personal time with free-as-in-beer (DaVinci Resolve) and free-as-in-speech (ffmpeg) software, and relying on donated expertise from team members.

We're now at the point where a modest investment would substantially increase both the quantity and quality of what the team can produce.  RustConf 2025 was a big event for the team.  The Rust All Hands 2026 will be bigger.  The team wants to be equipped for it.

The proposal is to allocate $15k from the Project Priorities budget to the team (without expiration, though the amount is estimated for 2026 work).

Here's where the money would go:

**Professional editing** (~$4,000).  The team has a backlog of 9 interviews that need editing, and we expect to record perhaps another 20 or more this year.  Editing has been our bottleneck.  It's the main constraint on our output.  It's a hard thing for volunteers to do.  Our editing needs are straightforward, and a professional editor can churn through these efficiently.  Commercial rates are around $200/video for straightforward work (audio alignment, color correction, normalization, title cards, trimming) and $300-500/video for more complex work.  (We've solicited and received a friendly quote that is more efficient than this, which we'll use if possible, but it's safer to budget based on commercial rates.)

**Professional videography** (~$6,000).  For heavy interview days at conferences — the All Hands and RustConf being the big ones — hiring a professional videographer to provide and run the equipment increases quality while freeing our team members to conduct interviews, engage with attendees, and make the most of limited face time with busy people.  A commercial day rate is around $750-1,500.  $6,000 covers 4 videographer-days across events this year.

**Equipment** (~$4,000).  For the remaining days, we need to do the videography ourselves.  Many of our members have taken on the cost of purchasing the necessary equipment themselves (cameras and lenses ($500 - ∞), wireless microphones ($300-500), lighting (also $300-350), tripods and stands (also $300-500), cables, batteries, carrying cases, etc.).  But some of our members need help with this.  We plan to purchase some equipment to be shipped around as needed.  We may also use equipment rental services for events.

**Software and services** (~$1,000).  Audio post-processing (Auphonic, ~$132/year), a remote interview platform (Riverside, ~$288/year), and miscellaneous production needs.

**Travel**.  Generally the travel of our members to events is funded by employers or by Project travel grants.  But if a member had exhausted the travel grant allowance and were traveling to an event primarily to conduct interviews for the team, we would fund it from this budget.

cc @plevasseur
