### PR TITLE
Enable triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,0 +1,1 @@
+# Triagebot configuration <https://forge.rust-lang.org/triagebot/index.html>


### PR DESCRIPTION
This enables triagebot with the default configuration which is listed at https://github.com/rust-lang/triagebot/blob/master/rust-lang.triagebot.toml. Some of these may be useful.

There weren't any other configs that I particularly want to enable, though others can open PRs if they have things they want to include.