### PR TITLE
Add extra outreachy allocation

### DIFF
--- a/budget/budget.dat
+++ b/budget/budget.dat
@@ -247,3 +247,8 @@
 2026-04-20 Content team 2026 allocation
   assets:content  $15,000
   assets:council
+
+2026-04-24 Outreachy 2026 extra allocation
+  ; https://github.com/rust-lang/leadership-council/issues/288
+  assets:mentors:outreachy  $7,000
+  assets:council


### PR DESCRIPTION
An extra $7k was allocated in https://github.com/rust-lang/leadership-council/issues/288.