### PR TITLE
Deallocate post-2026 funds from PM and compiler-ops

### DIFF
--- a/budget/budget.dat
+++ b/budget/budget.dat
@@ -457,3 +457,13 @@
 2026-07-10 PM1 invoice
   expenses:program-management  $2310  ; 2026-07 -- 5 days.
   liabilities:payables
+
+2026-07-17 Compiler-ops 2026-07 deallocation
+  ; https://github.com/rust-lang/leadership-council/pull/314
+  assets:compiler-ops  -$21,660.46
+  assets:council
+
+2026-07-17 Program management 2026-07 deallocation
+  ; https://github.com/rust-lang/leadership-council/pull/314
+  assets:program-management  -$132,761.79
+  assets:council


### PR DESCRIPTION
The LC had originally allocated $200k to program management in [LC#151] for 2025 (on a use-it-or-lose-it basis).  In a 2025-02-27 call with Foundation staff, it was communicated that the Foundation could not guarantee funding beyond that already allocated; the staff asked that the year-end cap on the funds be removed so that these funds could cover the year-long contracts planned for the program.

I reported on this in the 2025-02-28 council meeting.  On this basis, in the 2025-03-14 council meeting, we removed the 2025 restriction from these funds and extended the allocation to $240k (also in [LC#151]).  Similarly, on this basis, the delegated teams reduced the hiring plan to one PM from two.

The idea, in both of these actions, was that the Project needed to 1) provide sufficient assurances to those hired into the PM role about the continuity of the program and 2) be able to fund the program long enough to show success and attract further funding.

We've continued to budget for this program in this conservative way. In [LC#255], we allocated a further $160k to the program in support of expanding it.  On this basis, the delegated teams made a second PM hire.

Similarly, we budgeted conservatively for compiler-ops.  In [LC#114], we allocated $30k to the program, then allocated a further $25k in [LC#181] and $55k in [LC#244].  This was intended to leave the program with sufficient funds for 2026 with a buffer extending into 2027 -- to leave time to find more funding or to wind down the program if no more funds were found for the Project Priorities budget for 2027.

In communication made via our PDs, the Foundation has now guaranteed to hold on its side reserves and to provide for the continuity of these programs beyond the funds currently allocated in the Project Priorities budget.

Given that, it makes sense for us to hand back to the LC general fund the portion of these allocations that isn't needed to cover expected 2026 expenses.

For program management, we expect remaining 2026 expenditures to be below $109,620.  This is calculated by taking the high end of the number of days each PM might work in a month, multiplying by the daily rate and the number of uninvoiced months, then adding $6k to cover other program expenses, most notably travel.

For compiler-ops, we expect remaining 2026 expenditures to be below $30,240.  This is calculated by taking the maximum known monthly invoiced amount (in EUR) and multiplying by a (conservative) 1.2 USD/EUR exchange rate and the remaining uninvoiced months (and it assumes we will not be receiving an invoice for January 2026).

Subtracting those from the current budgets for these programs (less amounts invoiced and not yet reflected in assets), let's hand back:

- $132,761.79 from program management, leaving $109,620.
  - The $109,620 is $129,170 less the $19,550 in payables.
- $21,660.46 from compiler-ops, leaving $30,240.

[LC#151]: https://github.com/rust-lang/leadership-council/issues/151
[LC#255]: https://github.com/rust-lang/leadership-council/issues/255
[LC#114]: https://github.com/rust-lang/leadership-council/issues/114
[LC#181]: https://github.com/rust-lang/leadership-council/issues/181
[LC#244]: https://github.com/rust-lang/leadership-council/issues/244